### PR TITLE
Add Brazil SPA fixed-odds betting & Google Play Age Signals compliance

### DIFF
--- a/agent-os/hooks/app-store-compliance-guard.sh
+++ b/agent-os/hooks/app-store-compliance-guard.sh
@@ -185,6 +185,9 @@ if [ "$IS_IOS" -eq 1 ]; then
   if grep_has 'deleteAccount|delete account'; then
     grep_has 'mailto:|deactivate' && finding high "APPLE-ACCOUNT-DELETION-WEAK" "Account removal may be deactivate or mailto only" "Provide genuine in app deletion of the account and its data, not a deactivate or external form."
   fi
+  if grep_has 'fixed-odds|betting'; then
+    finding critical "APPLE-GAMBLING-BRAZIL-LICENSE" "Fixed-odds or betting keyword detected in sources" "Provide a valid fixed-odds betting license from the Secretariat of Prizes and Bets (SPA) in App Review Info, set age rating to A18, and submit a new version to trigger verification (Apple policy May 8, 2026)."
+  fi
   finding medium "APPLE-2.3-AGE-RATING-2026" "Verify the 2026 age rating questionnaire" "Answer the updated age rating questions (13 plus, 16 plus, 18 plus) in App Store Connect."
 fi
 
@@ -223,6 +226,9 @@ if [ "$IS_AND" -eq 1 ]; then
   fi
   if grep_has 'SYSTEM_ALERT_WINDOW|TYPE_APPLICATION_OVERLAY'; then
     finding high "ANDROID-OVERLAY-TAPJACKING" "System overlay permission present" "Remove overlay abuse. The overlay plus accessibility combination is a strong malware signal."
+  fi
+  if grep_has 'com\.google\.android\.play:age-signals|AgeSignalsManager|AgeSignalsRequest'; then
+    finding critical "GOOGLE-PLAY-AGE-SIGNALS-MISUSE" "Play Age Signals API dependency found" "Ensure age signals are ONLY used to provide age-appropriate experiences. Using them for advertising, marketing, user profiling, or analytics is a direct ToS violation that can result in immediate app suspension or takedown."
   fi
   finding medium "GOOGLE-12-TESTER-RULE" "Verify the closed testing requirement" "A new personal account needs 12 testers over 14 consecutive days before production."
 fi

--- a/data/detection-recipes.json
+++ b/data/detection-recipes.json
@@ -46,6 +46,8 @@
     "APPLE-ACCOUNT-DELETION-WEAK": "grep -rn 'deleteAccount\\|delete account' --include='*.swift' . && grep -rn 'mailto:\\|deactivate' --include='*.swift' .   # deletion must truly delete, not mailto or deactivate",
     "ANDROID-ACCOUNT-DELETION-URL": "grep -rn 'createAccount\\|signUp\\|register' --include='*.kt' --include='*.java' . && ! grep -rn 'deleteAccount\\|delete_account' .   # also set a data deletion URL in the Play listing",
     "APPLE-1.2-UGC-24H-ACTION": "grep -rni 'post\\|comment\\|upload\\|feed\\|community' --include='*.swift' . && ! grep -rni 'report\\|block user\\|EULA\\|moderation' --include='*.swift' .",
-    "GOOGLE-FAMILIES-AD-SDK": "grep -rn 'com.google.android.gms.ads\\|applovin\\|unity.*ads\\|ironsource' --include='*.gradle' . && grep -rni 'children\\|families\\|kids' --include='AndroidManifest.xml' ."
+    "GOOGLE-FAMILIES-AD-SDK": "grep -rn 'com.google.android.gms.ads\\|applovin\\|unity.*ads\\|ironsource' --include='*.gradle' . && grep -rni 'children\\|families\\|kids' --include='AndroidManifest.xml' .",
+    "APPLE-GAMBLING-BRAZIL-LICENSE": "grep -rni 'gambling\\|fixed-odds\\|betting' --include='*.swift' .   # then verify the SPA license is provided in App Review Information for Brazil storefront",
+    "GOOGLE-PLAY-AGE-SIGNALS-MISUSE": "grep -rn 'com.google.android.play:age-signals\\|AgeSignalsManager\\|AgeSignalsRequest' --include='*.gradle' --include='*.kts' --include='*.kt' --include='*.java' .   # if present, confirm age signals are never passed to ad, marketing, profiling, or analytics SDKs"
   }
 }

--- a/data/rejection-patterns.json
+++ b/data/rejection-patterns.json
@@ -551,6 +551,26 @@
       "detection": "New submission review notes omit one of the six sections. Screen recording on a physical device, app purpose, access instructions and test credentials, external services list, regional differences, and regulated industry documentation.",
       "signals": [],
       "fix": "Fill all six review notes sections using templates/REVIEW-NOTES-TEMPLATE.md. Source. truongduy2611 review_notes rules."
+    },
+    {
+      "id": "APPLE-GAMBLING-BRAZIL-LICENSE",
+      "platform": "apple",
+      "guideline": "3.1.1",
+      "title": "Missing Brazilian fixed-odds betting license",
+      "severity": "critical",
+      "detection": "An app that indicates gambling/betting features but does not provide a valid fixed-odds betting license from the Secretariat of Prizes and Bets (SPA) in its App Review Information section when distributing on the Brazil storefront.",
+      "signals": ["gambling", "fixed-odds betting", "Secretariat of Prizes and Bets", "SPA license"],
+      "fix": "Select 'Yes' to the gambling question in the age rating questionnaire (which automatically sets the Brazil age rating to A18), provide a valid fixed-odds betting license from the Secretariat of Prizes and Bets (SPA) in the App Review Information field, and submit a new app version for verification."
+    },
+    {
+      "id": "GOOGLE-PLAY-AGE-SIGNALS-MISUSE",
+      "platform": "google",
+      "guideline": "User Data",
+      "title": "Misuse of Play Age Signals API",
+      "severity": "critical",
+      "detection": "Usage of the Play Age Signals API (com.google.android.play:age-signals) in conjunction with advertising, marketing, user profiling, or analytics libraries, which violates Google Play's strict Terms of Service.",
+      "signals": ["com.google.android.play:age-signals", "AgeSignalsManager", "AgeSignalsRequest"],
+      "fix": "Ensure that information from the Play Age Signals API is solely used to provide age-appropriate content and experiences in compliance with laws. Do not use the API or its returned signals for advertising, marketing, user profiling, or analytics."
     }
   ]
 }

--- a/docs/GAMBLING-MATRIX.md
+++ b/docs/GAMBLING-MATRIX.md
@@ -26,6 +26,7 @@ Two rules sit above the whole matrix.
 | Category | Treatment | What you must do |
 |---|---|---|
 | Real money casino and betting | Licensed and geo restricted per country, free to download | Hold the license per region, restrict to licensed regions, free download |
+| Brazil fixed-odds betting (sports & virtual) | Regulated by the Secretariat of Prizes and Bets (SPA); license required for distribution in Brazil (enforced since May 8, 2026) | Provide a valid SPA license in the App Review Information section, submit a new app version for verification, and set the age rating to A18. |
 | Social casino and simulated gambling | A distinct category from real money, with its own age rating, allowed more widely but still rated | Rate it correctly, no real money payout |
 | Sweepstakes and dual currency sweeps coins | Frequently treated as gambling depending on the prize and consideration | Get legal review per market, geo restrict where it counts as gambling |
 | Cash prize skill tournaments and daily fantasy | Often regulated as gambling or as a regulated contest per state or country | License or restrict per jurisdiction |

--- a/docs/GLOBAL-REGULATORY-2026.md
+++ b/docs/GLOBAL-REGULATORY-2026.md
@@ -4,9 +4,11 @@ This document is the non-EU legal layer for App Store and Google Play compliance
 
 Every item is a HARD rule for any app that reaches users in the named market. Each carries a date and a source. Apple-backed items cite developer.apple.com so the reference stays Apple-anchored. Many US and global dates are under active litigation or legislative delay, so treat each effective date as the statutory date subject to injunction or amendment, and re-verify against the cited source before relying on it. Items that could not be confirmed against a primary source are labelled unverified in the last section.
 
-## 1. Apple's cross-region age-assurance spine (Apple-backed, check this first)
+## 1. Storefront-backed age-assurance spines (Apple and Google-backed)
 
-Several national and US-state laws are operated through Apple's own age-assurance machinery, so an audit checks this layer first.
+Several national and US-state laws are operated through storefront-specific age-assurance machinery, so an audit checks this layer first.
+
+### 1.1 Apple's cross-region age-assurance spine
 
 - Declared Age Range API. It returns a user's age band, not a birthdate, plus a signal for how age was confirmed (`governmentIDChecked`, `paymentChecked`, `selfDeclared`, `guardianDeclared`). The entitlement is `com.apple.developer.declared-age-range`. Version map. iOS and iPadOS 26 add the base self-declared and guardian-declared range. 26.2 adds verification methods and PermissionKit. 26.4 adds regulatory-requirement signals and a parental-acknowledgement sheet for a major app update. Full features build against the iOS 26.2 SDK with Xcode 26.2 or later. The API is available worldwide. Sources. [Apple age assurance](https://developer.apple.com/support/age-assurance/), [Apple Declared Age Range](https://developer.apple.com/documentation/declaredagerange/).
 - Apple names no specific law on the age-assurance page. it says "in certain regions, where legally required" and "consult your legal counsel". The country and state list lives in Apple's dated news posts, not the evergreen page. An audit must not read the region list off the support page.
@@ -25,6 +27,22 @@ Per-region storefront dates Apple has published.
 | Singapore | 24 February 2026 | 18-plus download block | not named |
 
 Sources. [Apple region age requirements](https://developer.apple.com/news/?id=f5zj08ey), [Apple Texas SB 2420](https://developer.apple.com/news/?id=btkirlj8).
+
+### 1.2 Google Play Age Signals API (v3 / beta)
+
+To help developers meet compliance obligations under age verification laws in jurisdictions such as Texas, Utah, Louisiana, and Brazil, Google Play provides a runtime client-side age signal interface.
+
+- **Purpose and Scope**: The Play Age Signals API retrieves age-related signals for users, notifies Google Play of significant app changes requiring parental approval, and receives notifications about revoked approvals. It only returns data for users based in regions where Play is required by law to provide age category data.
+- **Terms of Service (ToS)**: Usage is heavily restricted. Developers may only use information from the Play Age Signals API to provide age-appropriate content and experiences in compliance with laws. You **MUST NOT** use the API for any other purpose including, but not limited to, advertising, marketing, user profiling, or analytics. Misuse will result in the termination of API access and immediate app suspension or takedown.
+- **Integration & Dependency**: Integrate using `com.google.android.play:age-signals:0.0.3` (or subsequent versions). Supported on Android 6.0 (API level 23) and higher.
+- **Bands**: Default returned categories are 0-12, 13-15, 16-17, and 18+ (custom age ranges can also be received). Cached age signals are updated by Play within 2 to 8 weeks after the user's birthday.
+- **Data Safety**: No user data is collected, stored, or shared by the client-side library itself. Google Play's background services handle data governed by the Google Play ToS.
+- **Rollout Timeline**:
+  - **Brazil**: Started rolling out on March 17, 2026, to meet requirements under Brazil's Digital ECA.
+  - **Texas**: Started returning signals on May 28, 2026, for users who created accounts after that date to comply with Texas SB2420.
+  - Ongoing updates are provided for other US states (Utah, Louisiana).
+
+Sources. [Google Play Age Signals overview](https://developer.android.com/google/play/age-signals/v3/overview), [Use Play Age Signals API (beta)](https://developer.android.com/google/play/age-signals/v3/use-age-signals-api), [Google Play Developer Help](https://support.google.com/googleplay/android-developer/answer/16569691).
 
 ## 2. United States
 
@@ -53,7 +71,7 @@ These put duties on both the store and the developer, separate from broader soci
 | Louisiana | HB 570 | 30 June 2025 | delayed one year to 1 July 2027 |
 | Alabama | HB 161 | 9 March 2026 | 2027, exact date unverified |
 
-Common developer duties. request and receive an age category from the store. confirm whether verifiable parental consent exists for a minor account before use. assign an accurate age and suitability rating. re-request consent on a major change. limit use of age and consent data to compliance and delete it after verification (Texas is explicit on deletion). Sources. [Utah SB 142](https://le.utah.gov/~2025/bills/static/SB0142.html), [FPF comparison of the ASAAs](https://fpf.org/blog/comparing-enacted-app-store-accountability-acts/), [Wiley ASAA developments](https://www.wiley.law/alert-Key-Developments-With-State-App-Store-Accountability-Acts-as-Texas-Act-Takes-Effect).
+Common developer duties. request and receive an age category from the store. confirm whether verifiable parental consent exists for a minor account before use. assign an accurate age and suitability rating. re-request consent on a major change. limit use of age and consent data to compliance and delete it after verification (Texas is explicit on deletion). For Android apps, Google Play supports this via the Play Age Signals API, which began returning signals for eligible Texas accounts created after May 28, 2026. Sources. [Utah SB 142](https://le.utah.gov/~2025/bills/static/SB0142.html), [FPF comparison of the ASAAs](https://fpf.org/blog/comparing-enacted-app-store-accountability-acts/), [Wiley ASAA developments](https://www.wiley.law/alert-Key-Developments-With-State-App-Store-Accountability-Acts-as-Texas-Act-Takes-Effect).
 
 Apple discrepancy to flag. Apple's storefront date for Louisiana is 1 July 2026, while the statute was delayed to 1 July 2027. An audit flags the gap rather than assuming either date. Sources. [Apple region age requirements](https://developer.apple.com/news/?id=f5zj08ey), [Alston on the Louisiana delay](https://www.alstonprivacy.com/louisiana-delays-app-store-accountability-effective-date-to-july-2027/).
 
@@ -114,6 +132,7 @@ Common app duties. a privacy notice, an opt-out of targeted advertising, sale, a
 
 - Digital ECA (Law 15,211/2025), enforceable from 17 March 2026, on top of the LGPD and enforced by the ANPD. Accepted age-verification methods include document verification, facial age estimation, facial matching, and a CPF database check. a self-declaration checkbox no longer counts. The ANPD 2026 enforcement plan prioritises app stores and operating systems as gatekeepers. Penalty up to 50 million reais per violation or 10 percent of Brazilian revenue. Sources. [Digital ECA timeline](https://inplp.com/latest-news/article/the-digital-eca-brazils-new-age-verification-framework-and-enforcement-timeline/).
 - Apple blocks 18-plus downloads in Brazil from 24 February 2026, and loot-box apps auto-rate 18-plus on the Brazil storefront.
+- Google Play rolled out support for the Digital ECA on March 17, 2026, returning age signals for eligible Brazilian users through the Play Age Signals API.
 
 ### 3.4 Canada
 

--- a/docs/PLATFORM-MECHANICS-2026.md
+++ b/docs/PLATFORM-MECHANICS-2026.md
@@ -106,11 +106,15 @@ A health app completes the Health Apps Declaration (the Health Connect declarati
 
 Sources. [Play Console Health content and services](https://support.google.com/googleplay/android-developer/answer/16679511?hl=en), [Play Console Health Connect permissions](https://support.google.com/googleplay/android-developer/answer/12991134?hl=en).
 
-### 2.8 Real-money games
+### 2.8 Real-money games and Brazilian betting license (HARD)
 
-Google historically allowed real-money games only where a government licensing regime exists. a 2024 pilot opened a program for real-money games not covered by an existing regime (first in India, Mexico, Brazil), then Google paused the expansion of new types citing the absence of a central approval authority in some regions. India moved toward a developer self-declaration model in mid-2025, status evolving. Verify a real-money-game app is in a supported country with an accepted license or a valid self-declaration, with the real-money-game declarations, age-gating, geo-restriction, and the correct service-fee model in place.
+- **Google Real-Money Games**: Google historically allowed real-money games only where a government licensing regime exists. a 2024 pilot opened a program for real-money games not covered by an existing regime (first in India, Mexico, Brazil), then Google paused the expansion of new types citing the absence of a central approval authority in some regions. India moved toward a developer self-declaration model in mid-2025, status evolving. Verify a real-money-game app is in a supported country with an accepted license or a valid self-declaration, with the real-money-game declarations, age-gating, geo-restriction, and the correct service-fee model in place.
+- **Apple Brazilian Betting License (May 8, 2026)**: Following changes to Brazil's fixed-odds betting regulation, apps with fixed-odds betting (gambling) features can only be distributed on the App Store in Brazil with a valid fixed-odds betting license from the **Secretariat of Prizes and Bets (SPA)**.
+  - Answering "Yes" to the gambling question in the age rating questionnaire in App Store Connect will automatically set the app's Brazil age rating to **A18**.
+  - To trigger the license verification process, **a new app version must be submitted** for review; simply updating the App Review Information section in App Store Connect alone is insufficient and will not start the verification review.
+  - License information must be explicitly provided in the App Review Information section during the submission of the new version.
 
-Sources. [Google real-money games approach](https://android-developers.googleblog.com/2024/01/a-new-approach-to-real-money-games-on-google-play.html), [Google pauses RMG expansion (NEXT.io)](https://next.io/news/regulation/google-halts-rmg-expansion-on-play-store/).
+Sources. [Google real-money games approach](https://android-developers.googleblog.com/2024/01/a-new-approach-to-real-money-games-on-google-play.html), [Google pauses RMG expansion (NEXT.io)](https://next.io/news/regulation/google-halts-rmg-expansion-on-play-store/), Apple Developer News, "Brazilian betting license requirement for App Store availability" (May 8, 2026).
 
 ### 2.9 Media permissions, exact alarm, package visibility, and account-deletion URL
 

--- a/docs/PRE-SUBMISSION-CHECKLIST.md
+++ b/docs/PRE-SUBMISSION-CHECKLIST.md
@@ -77,13 +77,13 @@ Passing App Review does not make an app EU-legal. The full hard rules and source
 The full hard rules and sources are in docs/GLOBAL-REGULATORY-2026.md. This is legal, on top of App Review. Several dates are under active litigation, so re-verify each against the cited source.
 
 - [ ] Child-directed or under-13 data. COPPA verifiable parental consent, a separate opt-in for ad or third-party disclosure, a written retention policy and a written security program (general compliance date 22 April 2026).
-- [ ] US state App Store Accountability Acts (Utah, Texas, Louisiana, Alabama). the app requests an age category from the store, confirms parental consent for a minor, and re-requests on a major change, wired through the Declared Age Range API.
+- [ ] US state App Store Accountability Acts (Utah, Texas, Louisiana, Alabama). the app requests an age category from the store, confirms parental consent for a minor, and re-requests on a major change, wired through the Declared Age Range API (iOS) or the Play Age Signals API (Android, ensuring strict ToS compliance prohibiting ads, marketing, user profiling, or analytics use of age data).
 - [ ] Age rating set to 4-plus, 9-plus, 13-plus, 16-plus, or 18-plus, never Unrated, questionnaire re-answered by 31 January 2026.
 - [ ] US storefront external links are allowed with no entitlement and no disclosure sheet, no in-app alternative payment, and the commission question is treated as unsettled.
 - [ ] California and US state privacy. a privacy policy, notice at collection, know, delete, correct, "Do Not Sell or Share", "Limit Use of Sensitive PI", and honoring Global Privacy Control.
 - [ ] Biometric. written consent before capture, a public retention and destruction schedule, and no sale (Illinois BIPA, Texas CUBI).
 - [ ] Health app. the HIPAA gate, else the FTC Health Breach Notification Rule with a 60-day breach notice.
-- [ ] 18-plus download gating handled for Brazil, Australia, and Singapore for the Apple block of 24 February 2026.
+- [ ] 18-plus download gating handled for Brazil, Australia, and Singapore for the Apple block of 24 February 2026, and Google Play's Digital ECA age-assurance rollout for Brazil via the Play Age Signals API starting 17 March 2026.
 - [ ] UK Online Safety Act Highly Effective Age Assurance and the Children's-Code defaults for a likely-child service.
 - [ ] Australia under-16 age assurance for an age-restricted social media platform.
 - [ ] South Korea Korea-only binary with an approved payment provider if alternative billing is used.
@@ -101,6 +101,7 @@ Apple.
 - [ ] France ANSSI encryption declaration uploaded in App Store Connect if the app uses non-exempt encryption and ships on the French App Store.
 - [ ] App Store Connect content-rights question answered, with proof of rights available for any third-party content.
 - [ ] visionOS App Motion declared, and watchOS and tvOS built with the platform-26 SDK and Xcode 26 by 28 April 2026.
+- [ ] Fixed-odds betting apps distributed in Brazil provide a valid Secretariat of Prizes and Bets (SPA) license in the App Review Information, set the Brazil age rating to A18 via the questionnaire, and are submitted under a new app version for verification (since May 8, 2026).
 
 Android.
 
@@ -111,6 +112,7 @@ Android.
 - [ ] `targetSdkVersion` at least 35 today, planned for at least 36 by the 2026 deadline.
 - [ ] No unexpected launch-time or mid-task full-screen interstitial, and every interstitial is closable by 15 seconds.
 - [ ] Health app has the Health Apps Declaration, a core-function justification per Health Connect permission, the migrated Organization Account, and the correct medical-device label or disclaimer.
+- [ ] Real-money game apps in supported countries have the required licenses or self-declarations, geo-restrictions, age-gating, and comply with any relevant Play Age Signals API terms.
 
 Cross-cutting.
 

--- a/references/README.md
+++ b/references/README.md
@@ -6,12 +6,12 @@ A structured, AI loadable reference tree. Load the rule category and the app typ
 
 - [rules/metadata.md](rules/metadata.md). Metadata and store listing. 9 rules
 - [rules/privacy.md](rules/privacy.md). Privacy and data. 12 rules
-- [rules/payments.md](rules/payments.md). Payments, in app purchase, subscriptions. 5 rules
+- [rules/payments.md](rules/payments.md). Payments, in app purchase, subscriptions. 6 rules
 - [rules/design.md](rules/design.md). Design and login. 3 rules
 - [rules/performance.md](rules/performance.md). Performance and completeness. 8 rules
 - [rules/entitlements.md](rules/entitlements.md). Entitlements. 1 rules
 - [rules/safety.md](rules/safety.md). Safety and user generated content. 2 rules
-- [rules/android.md](rules/android.md). Google Play specific. 12 rules
+- [rules/android.md](rules/android.md). Google Play specific. 13 rules
 - [rules/export.md](rules/export.md). Export and build. 1 rules
 
 ## Guidelines by app type

--- a/references/rules/android.md
+++ b/references/rules/android.md
@@ -1,6 +1,6 @@
 # Rules. Google Play specific
 
-12 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
+13 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
 
 ## GOOGLE-DATASAFETY-MISMATCH
 
@@ -96,6 +96,22 @@ How to detect.
 
 ```bash
 grep -rn 'com.google.android.gms.ads\|applovin\|unity.*ads\|ironsource' --include='*.gradle' . && grep -rni 'children\|families\|kids' --include='AndroidManifest.xml' .
+```
+
+## GOOGLE-PLAY-AGE-SIGNALS-MISUSE
+
+- Title. Misuse of Play Age Signals API
+- Platform. google
+- Guideline or policy. User Data
+- Severity. critical
+- What triggers it. Usage of the Play Age Signals API (com.google.android.play:age-signals) in conjunction with advertising, marketing, user profiling, or analytics libraries, which violates Google Play's strict Terms of Service.
+- How to fix it. Ensure that information from the Play Age Signals API is solely used to provide age-appropriate content and experiences in compliance with laws. Do not use the API or its returned signals for advertising, marketing, user profiling, or analytics.
+- Detection signals. com.google.android.play:age-signals, AgeSignalsManager, AgeSignalsRequest
+
+How to detect.
+
+```bash
+grep -rn 'com.google.android.play:age-signals\|AgeSignalsManager\|AgeSignalsRequest' --include='*.gradle' --include='*.kts' --include='*.kt' --include='*.java' .   # if present, confirm age signals are never passed to ad, marketing, profiling, or analytics SDKs
 ```
 
 ## GOOGLE-TARGET-API

--- a/references/rules/payments.md
+++ b/references/rules/payments.md
@@ -1,6 +1,6 @@
 # Rules. Payments, in app purchase, subscriptions
 
-5 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
+6 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
 
 ## APPLE-3.1.1-EXTERNAL-PAYMENT
 
@@ -34,6 +34,22 @@ How to detect.
 
 ```bash
 grep -rn 'Stripe\|PayPal\|razorpay' --include='*.kt' --include='*.java' . && ! grep -rn 'BillingClient\|com.android.billingclient' .
+```
+
+## APPLE-GAMBLING-BRAZIL-LICENSE
+
+- Title. Missing Brazilian fixed-odds betting license
+- Platform. apple
+- Guideline or policy. 3.1.1
+- Severity. critical
+- What triggers it. An app that indicates gambling/betting features but does not provide a valid fixed-odds betting license from the Secretariat of Prizes and Bets (SPA) in its App Review Information section when distributing on the Brazil storefront.
+- How to fix it. Select 'Yes' to the gambling question in the age rating questionnaire (which automatically sets the Brazil age rating to A18), provide a valid fixed-odds betting license from the Secretariat of Prizes and Bets (SPA) in the App Review Information field, and submit a new app version for verification.
+- Detection signals. gambling, fixed-odds betting, Secretariat of Prizes and Bets, SPA license
+
+How to detect.
+
+```bash
+grep -rni 'gambling\|fixed-odds\|betting' --include='*.swift' .   # then verify the SPA license is provided in App Review Information for Brazil storefront
 ```
 
 ## BOTH-LOOTBOX-ODDS


### PR DESCRIPTION
Integrate Brazil's Secretariat of Prizes and Bets (SPA) licensing rules and Google Play's Age Signals API compliance framework into the playbook, automated guard, and checklists.

---
*PR created automatically by Jules for task [1828389736080486409](https://jules.google.com/task/1828389736080486409) started by @mjmirza*