### PR TITLE
Implement strict source trust hierarchy and verification rules

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,6 +21,46 @@ Every factual claim must trace to a live canonical source.
 
 A pull request that adds a guideline number without a source link will be asked for the source before merge.
 
+## Source Hierarchy and Trust Priorities
+
+To maintain the highest level of accuracy and regulatory alignment, all references and citations within this playbook must be evaluated and verified according to the following strict hierarchy of sources.
+
+### Trust Levels
+
+Priority 1: Official Regulatory and Standardization Bodies
+- European Commission
+- EUR-Lex
+- Official Journal of the European Union
+- ENISA (European Union Agency for Cybersecurity)
+- EDPB (European Data Protection Board)
+- FTC (Federal Trade Commission)
+- NIST (National Institute of Standards and Technology)
+- CISA (Cybersecurity and Infrastructure Security Agency)
+- ICO (Information Commissioner's Office)
+- Government publications
+
+Priority 2: Reputable News Agencies
+- Reuters
+- AP (Associated Press)
+- Bloomberg
+
+Priority 3: Academic Publications
+- Academic papers and peer-reviewed journals
+
+Priority 4: Industry Material
+- Industry blogs and vendor publications
+
+Priority 5: Social Media and AI Summaries
+- LinkedIn
+- Reddit
+- Twitter
+- AI generated summaries
+
+### Core Guidelines and Pull Request Rules
+
+- Never trust secondary sources before official sources.
+- Never create compliance pull requests using Priority 4 or Priority 5 sources unless verified by a Priority 1 source. Any citation or claim sourced from Priority 4 or 5 must be traceably corroborated by an official publication from Priority 1.
+
 ## How to add a rejection pattern
 
 1. Add the human facing entry to the matching doc in `docs/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Agent Guidelines: Source Trust Hierarchy and Verification
+
+When acting as an AI agent on this repository, you must strictly adhere to the following source trust hierarchy and verification rules when reviewing guidelines, updating policies, or proposing/creating compliance changes and pull requests.
+
+## Source Trust Hierarchy
+
+Priority 1: Official Regulatory and Standardization Bodies
+- European Commission
+- EUR-Lex
+- Official Journal of the European Union
+- ENISA (European Union Agency for Cybersecurity)
+- EDPB (European Data Protection Board)
+- FTC (Federal Trade Commission)
+- NIST (National Institute of Standards and Technology)
+- CISA (Cybersecurity and Infrastructure Security Agency)
+- ICO (Information Commissioner's Office)
+- Government publications
+
+Priority 2: Reputable News Agencies
+- Reuters
+- AP (Associated Press)
+- Bloomberg
+
+Priority 3: Academic Publications
+- Academic papers and peer-reviewed journals
+
+Priority 4: Industry Material
+- Industry blogs and vendor publications
+
+Priority 5: Social Media and AI Summaries
+- LinkedIn
+- Reddit
+- Twitter
+- AI generated summaries
+
+## Compliance Pull Request Rules
+
+- Never trust secondary sources before official sources.
+- Never create compliance pull requests using Priority 4 or Priority 5 sources unless verified by a Priority 1 source. Any citation or claim sourced from Priority 4 or 5 must be traceably corroborated by an official publication from Priority 1.

--- a/docs/EU-REGULATORY-2026.md
+++ b/docs/EU-REGULATORY-2026.md
@@ -201,6 +201,21 @@ These are Apple App Review and App Store Connect changes, layered on top of the 
 
 The inline links above are the primary and secondary sources. The authoritative pages to re-check for currency are the Apple developer support pages (DMA, external offers, Core Technology Fee, DSA trader, age ratings, upcoming requirements), the EU Commission digital-strategy pages, EUR-Lex for the regulation texts, and artificialintelligenceact.eu for the AI Act article texts.
 
+### Source Trust Hierarchy
+
+All sources used for establishing regulatory requirements must adhere to the following priority guidelines:
+
+- Priority 1 (Primary Official): European Commission, EUR-Lex, Official Journal of the European Union, ENISA, EDPB, FTC, NIST, CISA, ICO, and official government publications.
+- Priority 2 (Highly Reputable News): Reuters, AP (Associated Press), Bloomberg.
+- Priority 3 (Academic): Academic papers and peer-reviewed journals.
+- Priority 4 (Industry): Industry blogs and vendor publications.
+- Priority 5 (Social & Unverified): LinkedIn, Reddit, Twitter, and AI generated summaries.
+
+### Compliance Pull Request Rules
+
+- Never trust secondary sources before official sources.
+- Never create compliance pull requests using Priority 4 or Priority 5 sources unless verified by a Priority 1 source. Any citation or claim sourced from Priority 4 or 5 must be traceably corroborated by an official publication from Priority 1.
+
 ## 9. Verification and honesty note
 
 Confidence is high on the core dates and the sourced facts. Confirmed against primary or law-firm sources. the AI Act timeline and Article 50 and Article 99 figures, the DMA 500,000,000 euro fine dated 23 April 2025, Apple's DSA trader fields and the 17 February 2025 removal, the EAA date of 28 June 2025 and EN 301 549 and WCAG 2.1 AA, and the Apple 2025-2026 guideline and deadline dates.

--- a/docs/GLOBAL-REGULATORY-2026.md
+++ b/docs/GLOBAL-REGULATORY-2026.md
@@ -167,6 +167,21 @@ Common app duties. a privacy notice, an opt-out of targeted advertising, sale, a
 
 Apple facts cite developer.apple.com and apple.com. US federal dates cite the Federal Register and the FTC. state and global facts cite the legislature, the regulator, or a reputable law-firm source, cross-checked where a government page could not be machine-read.
 
+### Source Trust Hierarchy
+
+All sources used for establishing regulatory requirements must adhere to the following priority guidelines:
+
+- Priority 1 (Primary Official): European Commission, EUR-Lex, Official Journal of the European Union, ENISA, EDPB, FTC, NIST, CISA, ICO, and official government publications.
+- Priority 2 (Highly Reputable News): Reuters, AP (Associated Press), Bloomberg.
+- Priority 3 (Academic): Academic papers and peer-reviewed journals.
+- Priority 4 (Industry): Industry blogs and vendor publications.
+- Priority 5 (Social & Unverified): LinkedIn, Reddit, Twitter, and AI generated summaries.
+
+### Compliance Pull Request Rules
+
+- Never trust secondary sources before official sources.
+- Never create compliance pull requests using Priority 4 or Priority 5 sources unless verified by a Priority 1 source. Any citation or claim sourced from Priority 4 or 5 must be traceably corroborated by an official publication from Priority 1.
+
 Marked unverified, confirm against the primary source before relying on a figure. the South Korea PIPA effective date and the CEO-liability and 10-percent-turnover specifics. the Alabama HB 161 exact effective date. the exact Declared Age Range enum brackets (the Apple doc page renders as a client-side app that resisted an automated read, so the bands rest on Apple's Texas worked example). the California AADC partial-enforcement start date. the exact per-state Global Privacy Control required list and the 2026 penalty figures. the Australia Children's Online Privacy Code date. the Canada federal reform bill status. and the Google Android developer-verification rollout scope.
 
 The genuinely unsettled areas an audit treats as moving targets. the current US external-purchase commission (pending the Supreme Court, argument October 2026), the ASAA effective dates (all under litigation or delay), the California AADC scope, and the per-state Global Privacy Control list. Treat this document as HARD on the existence and direction of each obligation, and advisory on any specific number or date until re-verified against the cited source.

--- a/docs/PLATFORM-MECHANICS-2026.md
+++ b/docs/PLATFORM-MECHANICS-2026.md
@@ -201,6 +201,21 @@ Verify. if the app takes EU or UK card payments for real goods, SCA and 3D Secur
 
 Apple facts cite developer.apple.com. Android and Google Play facts cite developer.android.com and the Play Console help. legal facts cite the statute, the regulator, or the standards body. Where a government or Apple page rendered as a client-side app that resisted an automated read, the fact was cross-checked across reputable sources and is flagged here.
 
+### Source Trust Hierarchy
+
+All sources used for establishing regulatory requirements must adhere to the following priority guidelines:
+
+- Priority 1 (Primary Official): European Commission, EUR-Lex, Official Journal of the European Union, ENISA, EDPB, FTC, NIST, CISA, ICO, and official government publications.
+- Priority 2 (Highly Reputable News): Reuters, AP (Associated Press), Bloomberg.
+- Priority 3 (Academic): Academic papers and peer-reviewed journals.
+- Priority 4 (Industry): Industry blogs and vendor publications.
+- Priority 5 (Social & Unverified): LinkedIn, Reddit, Twitter, and AI generated summaries.
+
+### Compliance Pull Request Rules
+
+- Never trust secondary sources before official sources.
+- Never create compliance pull requests using Priority 4 or Priority 5 sources unless verified by a Priority 1 source. Any citation or claim sourced from Priority 4 or 5 must be traceably corroborated by an official publication from Priority 1.
+
 Marked unverified, confirm against the primary source before relying on a figure. the 2026 Android target API 36 date (widely reported, consistent with the annual release pattern, but the official target-sdk page still showed the 2025 text at fetch time). the exact `codesign`, `notarytool`, and `stapler` command strings (corroborated across sources, not copied from a rendered Apple page). the exact visionOS, watchOS, and tvOS per-device screenshot pixel dimensions (pull live from the App Store Connect screenshot page). the exact date Apple's Accessibility Nutrition Labels become mandatory (Apple says over time, no date published). the Google real-money-games India final rollout status. the EU CSA Regulation final form (in trilogue). the US BIS annual self-classification report specifics. and the PSD3 timing.
 
 Treat this document as HARD on the existence and direction of each obligation, and advisory on any specific number, version, or date until re-verified against the cited source.


### PR DESCRIPTION
This change implements a strict source trust hierarchy across the repository guidelines and documentation. It defines official bodies (such as European Commission, EUR-Lex, ENISA, EDPB, FTC, NIST, CISA, ICO, and government publications) under Priority 1, news agencies under Priority 2, academic papers under Priority 3, industry blogs under Priority 4, and social media/AI generated summaries under Priority 5. It establishes that secondary sources must never be trusted before official sources, and that compliance pull requests must not be created using Priority 4 or 5 sources unless verified by Priority 1. These rules are integrated into AGENTS.md, .github/CONTRIBUTING.md, and the source/verification sections of the major regulatory and mechanics documents.

---
*PR created automatically by Jules for task [1310616751421495460](https://jules.google.com/task/1310616751421495460) started by @mjmirza*