### PR TITLE
fix(guard): resolve deadline-checker.py under both ship shapes

### DIFF
--- a/agent-os/hooks/app-store-compliance-guard.sh
+++ b/agent-os/hooks/app-store-compliance-guard.sh
@@ -116,9 +116,16 @@ echo "Platforms. iOS=$IS_IOS Android=$IS_AND Web=$IS_WEB"
 echo ""
 
 # ----- run regulatory deadlines check -----
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-if [ -f "$REPO_ROOT/scripts/deadline-checker.py" ]; then
-  python3 "$REPO_ROOT/scripts/deadline-checker.py"
+# Tries both ship shapes. nested repo (agent-os/hooks/) and flat ~/.claude.
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEADLINE_PY=""
+for candidate in \
+  "$HOOK_DIR/../../scripts/deadline-checker.py" \
+  "$HOOK_DIR/../skills/app-store-compliance/scripts/deadline-checker.py"; do
+  if [ -f "$candidate" ]; then DEADLINE_PY="$candidate"; break; fi
+done
+if [ -n "$DEADLINE_PY" ]; then
+  python3 "$DEADLINE_PY"
   echo ""
 fi
 


### PR DESCRIPTION
## Summary

Found while syncing the just-merged #62 features into the local
`~/.claude` install (the actual shape most users end up running the
guard hook from). The regulatory-deadlines section resolved its
`deadline-checker.py` path as two-directories-up from the hook's own
location, which only matches the nested `agent-os/hooks/` repo layout.
Under the flat `~/.claude/hooks/` layout, that resolved to a
nonexistent path and the `[ -f ... ]` check silently skipped the whole
section, exit 0, no error, no test failure (the existing gauntlet
never exercises a flat install).

## Fix

Try both known ship shapes (nested repo, flat ~/.claude with
`skills/app-store-compliance/` as a sibling of `hooks/`) and use
whichever resolves. Verified live against a real project directory in
both layouts; the deadline section now prints in the flat layout where
it previously silently skipped.

## Test plan

- app-store-compliance-guard-test.sh 15 of 15 passed (unchanged)
- Manually verified against a throwaway project dir in the nested
  layout (agent-os/hooks/... under this repo)
- Manually verified against a throwaway project dir in the flat layout
  (~/.claude/hooks/... with ~/.claude/skills/app-store-compliance/
  installed as a sibling)
