### PR TITLE
feat: enable file-writing and complete PR generation in monitor-regulatory

### DIFF
--- a/docs/REGULATORY-POLICY-MIGRATION.md
+++ b/docs/REGULATORY-POLICY-MIGRATION.md
@@ -1,0 +1,54 @@
+<!-- REGULATORY_POLICY_MONITOR_START -->
+# Regulatory Policy Monitoring & Compliance Report
+
+This report is continuously generated and updated by `scripts/monitor-regulatory.py` to keep track of global regulatory changes.
+
+## Latest Monitored Policy Changes
+
+### EU AI Act Article 50 Transparency Obligations taking full effect in August 2026 (EU AI Act)
+- **Published**: Fri, 08 May 2026 12:00:00 GMT
+- **Official Link**: [https://digital-strategy.ec.europa.eu/en/library/draft-guidelines-implementation-transparency-obligations-certain-ai-systems-under-article-50-ai-act](https://digital-strategy.ec.europa.eu/en/library/draft-guidelines-implementation-transparency-obligations-certain-ai-systems-under-article-50-ai-act)
+- **Jurisdiction**: European Union
+- **Impact Level**: Critical
+- **Scan Verdict**: Found 23 file(s) containing active compliance signals.
+- **Suggested Migration Tasks**:
+    - [ ] Add clear in-app disclosures: 'You are interacting with an AI system.'
+    - [ ] Mark all synthetic text, audio, images, or video in a machine-readable format.
+    - [ ] Verify that no prohibited practices (such as biometric classification of sensitive traits) are used.
+    - [ ] Document a team AI literacy policy in compliance with Article 4.
+
+### FTC issues final updates to the COPPA Children's Online Privacy Rule (US COPPA)
+- **Published**: Tue, 22 Apr 2025 09:00:00 GMT
+- **Official Link**: [https://www.federalregister.gov/documents/2025/04/22/2025-05904/childrens-online-privacy-protection-rule](https://www.federalregister.gov/documents/2025/04/22/2025-05904/childrens-online-privacy-protection-rule)
+- **Jurisdiction**: United States (Federal)
+- **Impact Level**: Critical
+- **Scan Verdict**: Found 20 file(s) containing active compliance signals.
+- **Suggested Migration Tasks**:
+    - [ ] Implement verifiable parental consent methods (such as government photo ID verification) before collecting minor PII.
+    - [ ] Maintain a written data retention policy with an automated purging schedule for minor accounts.
+    - [ ] Ensure zero ad-tracking SDKs are active inside child-targeted sections.
+
+### European Accessibility Act enforcement begins across all EU Member States (European Accessibility Act)
+- **Published**: Sat, 28 Jun 2025 08:00:00 GMT
+- **Official Link**: [https://commission.europa.eu/strategy-and-policy/policies/justice-and-fundamental-rights/disability/union-equality-strategy-rights-persons-disabilities-2021-2030/european-accessibility-act_en](https://commission.europa.eu/strategy-and-policy/policies/justice-and-fundamental-rights/disability/union-equality-strategy-rights-persons-disabilities-2021-2030/european-accessibility-act_en)
+- **Jurisdiction**: European Union
+- **Impact Level**: High
+- **Scan Verdict**: Found 10 file(s) containing active compliance signals.
+- **Suggested Migration Tasks**:
+    - [ ] Audit all UI components to ensure screen-reader labels (accessibilityLabel) and traits are present.
+    - [ ] Verify support for system-wide font scaling (Dynamic Type) without breaking the layout.
+    - [ ] Maintain WCAG 2.1 AA color contrast compliance (at least 4.5:1 for normal text).
+    - [ ] Draft and publish an official accessibility statement reachable from within the app.
+
+### Unverified rumors of GDPR policy changes on Reddit forum (GDPR)
+- **Published**: Sun, 26 Jul 2026 12:00:00 GMT
+- **Official Link**: [https://reddit.com/r/privacy/comments/12345/GDPR_rumor](https://reddit.com/r/privacy/comments/12345/GDPR_rumor)
+- **Jurisdiction**: European Union
+- **Impact Level**: High
+- **Scan Verdict**: BLOCKED: Compliance Pull Request generation blocked. Announcement source is Priority 5 (unverified secondary source).
+- **Suggested Migration Tasks**:
+    - [ ] Ensure the app implements a clear, prominent consent modal before collecting personal data.
+    - [ ] Offer a genuine in-app account deletion mechanism that removes all associated personal data.
+    - [ ] Audit all analytics and tracking SDKs to ensure data flows are disabled until opt-in consent is given.
+
+<!-- REGULATORY_POLICY_MONITOR_END -->

--- a/docs/REGULATORY_COMPLIANCE_PR_DRAFT.md
+++ b/docs/REGULATORY_COMPLIANCE_PR_DRAFT.md
@@ -1,0 +1,287 @@
+# Regulatory Compliance Update: EU AI Act
+
+## Summary
+This compliance pull request introduces configuration updates and implementation pathways for EU AI Act, responding directly to the global announcement regarding 'EU AI Act Article 50 Transparency Obligations taking full effect in August 2026'. The objective is to establish proactive safeguards within the repository and ensure aligned code declarations.
+
+## Background
+Global technology distribution environments demand synchronized regulatory mapping. The 'EU AI Act' represents a core operational target enforced across the European Union jurisdiction. This update reconciles our deployment structures with updated administrative and statutory expectations.
+
+## Regulatory change
+Under updated frameworks, actors must demonstrate verifiable conformity with statutory directives. The EU AI Act places strict transparency requirements on AI-driven apps under Article 50 (interaction disclosure, synthetic marking) and bans prohibited practices under Article 5. All updates must pass static analysis checks before the application is bundled for storefront distribution.
+
+## Official citations
+Priority 1: Official Sources (Authoritative)
+- Authority: European Commission
+- Authority: Official Journal
+- Authority: EUR-Lex
+- Citation: Regulation (EU) 2024/1689 of the European Parliament and of the Council (OJ L, 2024/1689, 12.07.2024)
+- Citation: European Commission Draft Guidelines on Article 50 Transparency Obligations (May 2026)
+- Official Announcement Reference Link: https://digital-strategy.ec.europa.eu/en/library/draft-guidelines-implementation-transparency-obligations-certain-ai-systems-under-article-50-ai-act
+Priority 2: Reputable News (Supporting Context Only)
+- Reuters Legal Regulatory Watch Feed (2026)
+Priority 3: Academic Papers (Theoretical Context Only)
+- Global Privacy and Tech Standards Annual Digest (2026)
+Priority 4: Industry blogs (Consultative Reference Only)
+- Enterprise Compliance & Risk Playbook Summaries
+Priority 5: Social media and AI summaries
+- Verified against Priority 1 prior to compilation. No unverified Priority 4 or 5 information is used.
+
+## Affected files
+The following repository files have been identified as potentially in scope or containing relevant patterns:
+- `README.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `templates/REVIEW-NOTES-TEMPLATE.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `references/guidelines/by-app-type/ai-and-generative-apps.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `references/rules/privacy.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `references/rules/metadata.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `references/rules/safety.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `docs/EU-REGULATORY-2026.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `docs/BY-APP-TYPE.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `docs/ANDROID-POLICY-MIGRATION.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `docs/ADVANCED-2026.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `docs/GLOBAL-REGULATORY-2026.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `docs/REGULATORY_COMPLIANCE_PR_DRAFT.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `docs/COMPETITIVE-GAP-ANALYSIS.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `docs/APPLE.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `docs/AI-POLICY-MIGRATION.md`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `scripts/metadata-audit.py`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `scripts/release-audit.py`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `scripts/monitor-android.py`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `scripts/monitor-regulatory.py`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `scripts/monitor.py`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `scripts/monitor-ai-policy.py`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `data/detection-recipes.json`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+- `data/rejection-patterns.json`: Scanned file matching regex signature `openai|anthropic|chatgpt|llm|generativelanguage|api\.openai\.com|stable[ -]diffusion|CoreML|DeclaredAgeRange`
+
+
+## Risk assessment
+CRITICAL RISK: Failure to adopt this framework poses immediate distribution blockages. State-level regulators and app store validators actively reject non-conforming builds or impose substantial administrative penalties.
+
+## Migration steps
+- Add clear in-app disclosures: 'You are interacting with an AI system.'
+- Mark all synthetic text, audio, images, or video in a machine-readable format.
+- Verify that no prohibited practices (such as biometric classification of sensitive traits) are used.
+- Document a team AI literacy policy in compliance with Article 4.
+- Run scripts/validate.py to ensure patterns and data structures remain in a compliant state.
+
+## Backward compatibility
+These changes represent modular updates to configurations, declarations, and metadata files. No existing consumer APIs or core operational classes are deprecated in a breaking manner. Backward compatibility for existing deployed versions is fully maintained.
+
+## Implementation checklist
+- [ ] Identify and isolate modules referencing monitored keyword patterns.
+- [ ] Update target declarations in configuration files matching *.swift, *.py, *.js, *.ts, *.json, *.md.
+- [ ] Implement the following step: Add clear in-app disclosures: 'You are interacting with an AI system.'
+
+## Testing checklist
+- [ ] Execute clean compilation on localized developer machines.
+- [ ] Conduct manual walkthroughs of affected user-interaction channels (disclosures, prompts, and options).
+- [ ] Run static analysis scripts (validate.py) to confirm zero schema errors.
+
+## Documentation checklist
+- [ ] Update internal repository playbooks and compliance files.
+- [ ] Cross-reference documentation with guidelines in docs/EU-REGULATORY-2026.md.
+
+## Compliance impact
+Integrating these pathways aligns the repository with major global regulations, reducing regulatory risk profile to low and protecting developer enterprise distribution credentials.
+
+## Breaking changes
+This update contains zero functional breaking changes. No existing consumer-facing features are restricted or disabled as a result of these compliance declarations.
+
+## Review checklist
+- [ ] Ensure the diff is entirely emoji-free.
+- [ ] Verify that official citations are correctly indexed and traceable.
+- [ ] Confirm that no unapproved third-party tracking libraries have been introduced.
+
+## Approver recommendations
+- Principal Compliance Counsel (for regulatory signoff)
+- Mobile Platform Engineering Architect (for technical validation)
+- Director of Information Security (for verification of privacy protocols)
+
+---
+*Generated automatically by the Regulatory Intelligence Agent Monitor. Strict Emoji-Free Policy enforced.*
+
+---
+
+# Regulatory Compliance Update: US COPPA
+
+## Summary
+This compliance pull request introduces configuration updates and implementation pathways for US COPPA, responding directly to the global announcement regarding 'FTC issues final updates to the COPPA Children's Online Privacy Rule'. The objective is to establish proactive safeguards within the repository and ensure aligned code declarations.
+
+## Background
+Global technology distribution environments demand synchronized regulatory mapping. The 'US COPPA' represents a core operational target enforced across the United States (Federal) jurisdiction. This update reconciles our deployment structures with updated administrative and statutory expectations.
+
+## Regulatory change
+Under updated frameworks, actors must demonstrate verifiable conformity with statutory directives. COPPA protects under-13 children, and the 2025/2026 Amended Rule adds biometric identifiers to PII, mandates separate opt-in consent for ads, and requires a written security program. All updates must pass static analysis checks before the application is bundled for storefront distribution.
+
+## Official citations
+Priority 1: Official Sources (Authoritative)
+- Authority: FTC
+- Authority: Federal Register
+- Citation: Children's Online Privacy Protection Act, 15 U.S.C. 6501-6508
+- Citation: FTC Amended Children's Online Privacy Protection Rule (90 FR 16918, April 2025)
+- Official Announcement Reference Link: https://www.federalregister.gov/documents/2025/04/22/2025-05904/childrens-online-privacy-protection-rule
+Priority 2: Reputable News (Supporting Context Only)
+- Reuters Legal Regulatory Watch Feed (2026)
+Priority 3: Academic Papers (Theoretical Context Only)
+- Global Privacy and Tech Standards Annual Digest (2026)
+Priority 4: Industry blogs (Consultative Reference Only)
+- Enterprise Compliance & Risk Playbook Summaries
+Priority 5: Social media and AI summaries
+- Verified against Priority 1 prior to compilation. No unverified Priority 4 or 5 information is used.
+
+## Affected files
+The following repository files have been identified as potentially in scope or containing relevant patterns:
+- `CHANGELOG.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `AGENTS.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `README.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `references/README.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `references/guidelines/by-app-type/kids-category-and-families.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `references/rules/android.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `agent-os/commands/app-store-audit.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `agent-os/skill/SKILL.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `docs/EU-REGULATORY-2026.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `docs/BY-APP-TYPE.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `docs/ANDROID-POLICY-MIGRATION.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `docs/GOOGLE-PLAY.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `docs/ADVANCED-2026.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `docs/GLOBAL-REGULATORY-2026.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `docs/REGULATORY_COMPLIANCE_PR_DRAFT.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `docs/COMPETITIVE-GAP-ANALYSIS.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `docs/APPLE.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `docs/MOBILE-SECURITY-2026.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `docs/REGULATORY-POLICY-MIGRATION.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+- `docs/PRE-SUBMISSION-CHECKLIST.md`: Scanned file matching regex signature `coppa|under-13|kids|parentalGate|parentalConsent|biometric|gait|voiceprint|facialTemplate`
+
+
+## Risk assessment
+CRITICAL RISK: Failure to adopt this framework poses immediate distribution blockages. State-level regulators and app store validators actively reject non-conforming builds or impose substantial administrative penalties.
+
+## Migration steps
+- Implement verifiable parental consent methods (such as government photo ID verification) before collecting minor PII.
+- Maintain a written data retention policy with an automated purging schedule for minor accounts.
+- Ensure zero ad-tracking SDKs are active inside child-targeted sections.
+- Run scripts/validate.py to ensure patterns and data structures remain in a compliant state.
+
+## Backward compatibility
+These changes represent modular updates to configurations, declarations, and metadata files. No existing consumer APIs or core operational classes are deprecated in a breaking manner. Backward compatibility for existing deployed versions is fully maintained.
+
+## Implementation checklist
+- [ ] Identify and isolate modules referencing monitored keyword patterns.
+- [ ] Update target declarations in configuration files matching *.swift, Info.plist, *.md.
+- [ ] Implement the following step: Implement verifiable parental consent methods (such as government photo ID verification) before collecting minor PII.
+
+## Testing checklist
+- [ ] Execute clean compilation on localized developer machines.
+- [ ] Conduct manual walkthroughs of affected user-interaction channels (disclosures, prompts, and options).
+- [ ] Run static analysis scripts (validate.py) to confirm zero schema errors.
+
+## Documentation checklist
+- [ ] Update internal repository playbooks and compliance files.
+- [ ] Cross-reference documentation with guidelines in docs/GLOBAL-REGULATORY-2026.md.
+
+## Compliance impact
+Integrating these pathways aligns the repository with major global regulations, reducing regulatory risk profile to low and protecting developer enterprise distribution credentials.
+
+## Breaking changes
+This update contains zero functional breaking changes. No existing consumer-facing features are restricted or disabled as a result of these compliance declarations.
+
+## Review checklist
+- [ ] Ensure the diff is entirely emoji-free.
+- [ ] Verify that official citations are correctly indexed and traceable.
+- [ ] Confirm that no unapproved third-party tracking libraries have been introduced.
+
+## Approver recommendations
+- Principal Compliance Counsel (for regulatory signoff)
+- Mobile Platform Engineering Architect (for technical validation)
+- Director of Information Security (for verification of privacy protocols)
+
+---
+*Generated automatically by the Regulatory Intelligence Agent Monitor. Strict Emoji-Free Policy enforced.*
+
+---
+
+# Regulatory Compliance Update: European Accessibility Act
+
+## Summary
+This compliance pull request introduces configuration updates and implementation pathways for European Accessibility Act, responding directly to the global announcement regarding 'European Accessibility Act enforcement begins across all EU Member States'. The objective is to establish proactive safeguards within the repository and ensure aligned code declarations.
+
+## Background
+Global technology distribution environments demand synchronized regulatory mapping. The 'European Accessibility Act' represents a core operational target enforced across the European Union jurisdiction. This update reconciles our deployment structures with updated administrative and statutory expectations.
+
+## Regulatory change
+Under updated frameworks, actors must demonstrate verifiable conformity with statutory directives. The EAA mandates that digital services, including mobile applications and e-commerce websites, meet strict accessibility requirements of EN 301 549 (based on WCAG 2.1 AA) and publish an accessibility statement. All updates must pass static analysis checks before the application is bundled for storefront distribution.
+
+## Official citations
+Priority 1: Official Sources (Authoritative)
+- Authority: European Commission
+- Authority: Official Journal
+- Citation: Directive (EU) 2019/882 of the European Parliament and of the Council of 17 April 2019 on the accessibility requirements for products and services
+- Citation: Harmonised Standard EN 301 549 Chapter 11 (Accessibility requirements for non-web software)
+- Official Announcement Reference Link: https://commission.europa.eu/strategy-and-policy/policies/justice-and-fundamental-rights/disability/union-equality-strategy-rights-persons-disabilities-2021-2030/european-accessibility-act_en
+Priority 2: Reputable News (Supporting Context Only)
+- Reuters Legal Regulatory Watch Feed (2026)
+Priority 3: Academic Papers (Theoretical Context Only)
+- Global Privacy and Tech Standards Annual Digest (2026)
+Priority 4: Industry blogs (Consultative Reference Only)
+- Enterprise Compliance & Risk Playbook Summaries
+Priority 5: Social media and AI summaries
+- Verified against Priority 1 prior to compilation. No unverified Priority 4 or 5 information is used.
+
+## Affected files
+The following repository files have been identified as potentially in scope or containing relevant patterns:
+- `CHANGELOG.md`: Scanned file matching regex signature `accessibilityLabel|accessibilityTraits|VoiceOver|DynamicType|contrast|accessibilityHint`
+- `AGENTS.md`: Scanned file matching regex signature `accessibilityLabel|accessibilityTraits|VoiceOver|DynamicType|contrast|accessibilityHint`
+- `README.md`: Scanned file matching regex signature `accessibilityLabel|accessibilityTraits|VoiceOver|DynamicType|contrast|accessibilityHint`
+- `references/rules/performance.md`: Scanned file matching regex signature `accessibilityLabel|accessibilityTraits|VoiceOver|DynamicType|contrast|accessibilityHint`
+- `references/rules/android.md`: Scanned file matching regex signature `accessibilityLabel|accessibilityTraits|VoiceOver|DynamicType|contrast|accessibilityHint`
+- `docs/EU-REGULATORY-2026.md`: Scanned file matching regex signature `accessibilityLabel|accessibilityTraits|VoiceOver|DynamicType|contrast|accessibilityHint`
+- `docs/PLATFORM-MECHANICS-2026.md`: Scanned file matching regex signature `accessibilityLabel|accessibilityTraits|VoiceOver|DynamicType|contrast|accessibilityHint`
+- `docs/REGULATORY_COMPLIANCE_PR_DRAFT.md`: Scanned file matching regex signature `accessibilityLabel|accessibilityTraits|VoiceOver|DynamicType|contrast|accessibilityHint`
+- `docs/REGULATORY-POLICY-MIGRATION.md`: Scanned file matching regex signature `accessibilityLabel|accessibilityTraits|VoiceOver|DynamicType|contrast|accessibilityHint`
+- `docs/PRE-SUBMISSION-CHECKLIST.md`: Scanned file matching regex signature `accessibilityLabel|accessibilityTraits|VoiceOver|DynamicType|contrast|accessibilityHint`
+
+
+## Risk assessment
+HIGH RISK: Submitting updates without correct declarations increases manual audit times and poses rejection risks during storefront reviews, with potential fines under regional data protection laws.
+
+## Migration steps
+- Audit all UI components to ensure screen-reader labels (accessibilityLabel) and traits are present.
+- Verify support for system-wide font scaling (Dynamic Type) without breaking the layout.
+- Maintain WCAG 2.1 AA color contrast compliance (at least 4.5:1 for normal text).
+- Draft and publish an official accessibility statement reachable from within the app.
+- Run scripts/validate.py to ensure patterns and data structures remain in a compliant state.
+
+## Backward compatibility
+These changes represent modular updates to configurations, declarations, and metadata files. No existing consumer APIs or core operational classes are deprecated in a breaking manner. Backward compatibility for existing deployed versions is fully maintained.
+
+## Implementation checklist
+- [ ] Identify and isolate modules referencing monitored keyword patterns.
+- [ ] Update target declarations in configuration files matching *.swift, *.storyboard, *.xib, *.html, *.md.
+- [ ] Implement the following step: Audit all UI components to ensure screen-reader labels (accessibilityLabel) and traits are present.
+
+## Testing checklist
+- [ ] Execute clean compilation on localized developer machines.
+- [ ] Conduct manual walkthroughs of affected user-interaction channels (disclosures, prompts, and options).
+- [ ] Run static analysis scripts (validate.py) to confirm zero schema errors.
+
+## Documentation checklist
+- [ ] Update internal repository playbooks and compliance files.
+- [ ] Cross-reference documentation with guidelines in docs/EU-REGULATORY-2026.md.
+
+## Compliance impact
+Integrating these pathways aligns the repository with major global regulations, reducing regulatory risk profile to low and protecting developer enterprise distribution credentials.
+
+## Breaking changes
+This update contains zero functional breaking changes. No existing consumer-facing features are restricted or disabled as a result of these compliance declarations.
+
+## Review checklist
+- [ ] Ensure the diff is entirely emoji-free.
+- [ ] Verify that official citations are correctly indexed and traceable.
+- [ ] Confirm that no unapproved third-party tracking libraries have been introduced.
+
+## Approver recommendations
+- Principal Compliance Counsel (for regulatory signoff)
+- Mobile Platform Engineering Architect (for technical validation)
+- Director of Information Security (for verification of privacy protocols)
+
+---
+*Generated automatically by the Regulatory Intelligence Agent Monitor. Strict Emoji-Free Policy enforced.*

--- a/scripts/monitor-regulatory-test.sh
+++ b/scripts/monitor-regulatory-test.sh
@@ -109,6 +109,36 @@ if echo "$EU_JSON" | grep -q '"proposed_pull_request": null'; then
 fi
 echo "[PASS] Allowed verified Priority 1 sources successfully"
 
+# Test 8: Verify file-writing capabilities and 15-section check in output files
+echo "[TEST] Verifying output file creation and contents..."
+TEST_MIG="/tmp/test_migration.md"
+TEST_PR="/tmp/test_pr_draft.md"
+rm -f "$TEST_MIG" "$TEST_PR"
+
+python3 "$MON_SCRIPT" --project "$REPO_ROOT" --simulate "EU AI Act" --output-docs "$TEST_MIG" --pr-output "$TEST_PR" > /dev/null
+
+if [ ! -f "$TEST_MIG" ] || [ ! -s "$TEST_MIG" ]; then
+  echo "[ERROR] Failed to create or write to $TEST_MIG"
+  exit 1
+fi
+echo "[PASS] Successfully created and wrote documentation to $TEST_MIG"
+
+if [ ! -f "$TEST_PR" ] || [ ! -s "$TEST_PR" ]; then
+  echo "[ERROR] Failed to create or write to $TEST_PR"
+  exit 1
+fi
+echo "[PASS] Successfully created and wrote PR draft to $TEST_PR"
+
+for sect in "${SECTIONS[@]}"; do
+  if ! grep -q "## $sect" "$TEST_PR"; then
+    echo "[ERROR] Missing expected section $sect in written file: $TEST_PR"
+    exit 1
+  fi
+done
+echo "[PASS] All 15 required sections verified inside the written PR draft file"
+
+rm -f "$TEST_MIG" "$TEST_PR"
+
 echo ""
 echo "[SUCCESS] All tests passed successfully."
 exit 0

--- a/scripts/monitor-regulatory.py
+++ b/scripts/monitor-regulatory.py
@@ -3,6 +3,7 @@
 (EU/UK/US/CA/AU/SG/intl) against a source trust hierarchy. See README.md."""
 
 import os
+import sys
 import re
 import json
 import argparse
@@ -1057,6 +1058,68 @@ def print_text_report(report_items, project_path):
         print("-" * 80)
 
 
+def update_documentation(report_items, output_filepath):
+    """
+    Appends the latest regulatory policy findings and migration tasks directly to the output compliance file.
+    """
+    report_content = [
+        "<!-- REGULATORY_POLICY_MONITOR_START -->",
+        "# Regulatory Policy Monitoring & Compliance Report",
+        "",
+        "This report is continuously generated and updated by `scripts/monitor-regulatory.py` to keep track of global regulatory changes.",
+        "",
+        "## Latest Monitored Policy Changes",
+        "",
+    ]
+
+    for item in report_items:
+        report_content.append(f"### {item['announcement_title']} ({item['track']})")
+        report_content.append(f"- **Published**: {item['announcement_pubDate']}")
+        report_content.append(f"- **Official Link**: [{item['announcement_link']}]({item['announcement_link']})")
+        report_content.append(f"- **Jurisdiction**: {item['jurisdiction']}")
+        report_content.append(f"- **Impact Level**: {item['compliance_impact']}")
+        report_content.append(f"- **Scan Verdict**: {item['scan_verdict']}")
+        report_content.append("- **Suggested Migration Tasks**:")
+        for task in item["migration_tasks"]:
+            report_content.append(f"    - [ ] {task}")
+        report_content.append("")
+
+    report_content.append("<!-- REGULATORY_POLICY_MONITOR_END -->")
+
+    # Write to the output file
+    try:
+        os.makedirs(os.path.dirname(output_filepath) or ".", exist_ok=True)
+        with open(output_filepath, "w", encoding="utf-8") as f:
+            f.write("\n".join(report_content))
+        print(f"Documentation updated/created successfully at: {output_filepath}")
+    except Exception as e:
+        print(f"Error writing documentation to {output_filepath}: {e}", file=sys.stderr)
+
+
+def generate_and_save_pr_draft(report_items, output_filepath):
+    """
+    Compiles all non-blocked proposed pull requests into a single PR draft file.
+    """
+    pr_drafts = []
+    for item in report_items:
+        pr = item.get("proposed_pull_request")
+        if pr:
+            pr_drafts.append(pr["description"])
+
+    if not pr_drafts:
+        content = "# PULL REQUEST DRAFT: Regulatory Compliance Update\n\nNo active or verified regulatory compliance pull requests generated."
+    else:
+        content = "\n\n---\n\n".join(pr_drafts)
+
+    try:
+        os.makedirs(os.path.dirname(output_filepath) or ".", exist_ok=True)
+        with open(output_filepath, "w", encoding="utf-8") as f:
+            f.write(content)
+        print(f"PR draft written successfully to: {output_filepath}")
+    except Exception as e:
+        print(f"Error writing PR draft to {output_filepath}: {e}", file=sys.stderr)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Regulatory Intelligence Agent Monitor."
@@ -1073,6 +1136,18 @@ def main():
         "--json", action="store_true", help="Output report in JSON format"
     )
     parser.add_argument(
+        "--output-docs",
+        type=str,
+        default="docs/REGULATORY-POLICY-MIGRATION.md",
+        help="Filepath to write migration tasks / docs updates",
+    )
+    parser.add_argument(
+        "--pr-output",
+        type=str,
+        default="docs/REGULATORY_COMPLIANCE_PR_DRAFT.md",
+        help="Filepath to save the drafted PR",
+    )
+    parser.add_argument(
         "--verbose", action="store_true", help="Print verbose execution logs"
     )
 
@@ -1086,6 +1161,9 @@ def main():
         print(json.dumps(report_items, indent=2))
     else:
         print_text_report(report_items, args.project)
+        if report_items:
+            update_documentation(report_items, args.output_docs)
+            generate_and_save_pr_draft(report_items, args.pr_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change enables scripts/monitor-regulatory.py to write the tracking documentation and drafted PRs to physical files (docs/REGULATORY-POLICY-MIGRATION.md and docs/REGULATORY_COMPLIANCE_PR_DRAFT.md) by default, similar to the other monitoring scripts.

The drafted Pull Request contains exactly the 15 required sections in detailed formatting:
1. Summary
2. Background
3. Regulatory change
4. Official citations
5. Affected files
6. Risk assessment
7. Migration steps
8. Backward compatibility
9. Implementation checklist
10. Testing checklist
11. Documentation checklist
12. Compliance impact
13. Breaking changes
14. Review checklist
15. Approver recommendations

The test suite monitor-regulatory-test.sh was also updated to verify that files are successfully created and structured with all 15 required sections. All tests and global checks pass with 100% success rate and zero errors or warnings.

---
*PR created automatically by Jules for task [15446470146214660102](https://jules.google.com/task/15446470146214660102) started by @mjmirza*