### PR TITLE
feat: add EU e-Evidence and Contract Withdrawal Button compliance tracking

### DIFF
--- a/agent-os/hooks/app-store-compliance-guard-test.sh
+++ b/agent-os/hooks/app-store-compliance-guard-test.sh
@@ -191,6 +191,46 @@ else
 fi
 rm -rf "$D"
 
+# 18 e-Evidence violation blocks
+D="$(mktemp -d)"; mkdir -p "$D"
+printf '{"name":"t"}' > "$D/package.json"
+printf '<html><body>We process EU e-evidence and comply with production orders.</body></html>' > "$D/index.html"
+OUT="$(bash "$GUARD" "$D" 2>&1)"; RC=$?
+echo "$OUT" | grep -q 'BOTH-E-EVIDENCE-COMPLIANCE-MISSING' && ok "e-Evidence violation blocks" || bad "e-Evidence violation blocks"
+rm -rf "$D"
+
+# 19 e-Evidence clean stays silent
+D="$(mktemp -d)"; mkdir -p "$D"
+printf '{"name":"t"}' > "$D/package.json"
+printf '<html><body>We process EU e-evidence with our legal representative.</body></html>' > "$D/index.html"
+OUT="$(bash "$GUARD" "$D" 2>&1)"; RC=$?
+if ! echo "$OUT" | grep -q 'BOTH-E-EVIDENCE-COMPLIANCE-MISSING'; then
+  ok "e-Evidence clean stays silent"
+else
+  bad "e-Evidence clean stays silent"
+fi
+rm -rf "$D"
+
+# 20 Contract withdrawal button missing blocks
+D="$(mktemp -d)"; mkdir -p "$D"
+printf '{"name":"t"}' > "$D/package.json"
+printf '<html><body>Get a premium subscription today.</body></html>' > "$D/index.html"
+OUT="$(bash "$GUARD" "$D" 2>&1)"; RC=$?
+echo "$OUT" | grep -q 'BOTH-WITHDRAWAL-BUTTON-MISSING' && ok "Contract withdrawal button missing blocks" || bad "Contract withdrawal button missing blocks"
+rm -rf "$D"
+
+# 21 Contract withdrawal button clean stays silent
+D="$(mktemp -d)"; mkdir -p "$D"
+printf '{"name":"t"}' > "$D/package.json"
+printf '<html><body>Get a premium subscription today. Click our withdrawal button to cancel.</body></html>' > "$D/index.html"
+OUT="$(bash "$GUARD" "$D" 2>&1)"; RC=$?
+if ! echo "$OUT" | grep -q 'BOTH-WITHDRAWAL-BUTTON-MISSING'; then
+  ok "Contract withdrawal button clean stays silent"
+else
+  bad "Contract withdrawal button clean stays silent"
+fi
+rm -rf "$D"
+
 echo ""
 echo "app-store-compliance-guard-test: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/agent-os/hooks/app-store-compliance-guard.sh
+++ b/agent-os/hooks/app-store-compliance-guard.sh
@@ -140,6 +140,14 @@ fi
 if grep_has 'subscri(be|ption)|auto.renew|membership' && grep_has '[Cc]all.{0,25}[Cc]ancel|[Cc]ancel.{0,25}[Cc]all|[Mm]ail.{0,25}[Cc]ancel|[Ww]rite.{0,25}[Cc]ancel|[Cc]ancel.{0,15}(in.person|by.phone|by.mail)'; then
   finding high "BOTH-SUBSCRIPTION-HARD-CANCEL" "Subscription cancellation appears to require a phone call, mail, or an in-person visit" "Provide a self-service cancellation path at least as easy as sign-up (FTC Section 5, ROSCA, and CA/NY/MA negative-option laws)."
 fi
+# e-Evidence Package compliance
+if grep_has 'e-[Ee]vidence|[Ee]uropean [Pp]roduction [Oo]rder|[Ee]uropean [Pp]reservation [Oo]rder|[Ee]mergency [Dd]ata [Pp]roduction' && ! grep_has '[Ll]egal [Rr]epresentative|[Ll]aw [Ee]nforcement [Rr]equest'; then
+  finding high "BOTH-E-EVIDENCE-COMPLIANCE-MISSING" "Missing legal representative or emergency data-production response procedures for the EU e-Evidence Package" "Designate an establishment or appoint a legal representative in the EU, and establish internal protocols to deliver user data securely within 8 hours in emergency situations."
+fi
+# Contract withdrawal button compliance
+if grep_has 'subscri(be|ption)|auto.renew|membership' && ! grep_has '[Ww]ithdrawal [Bb]utton|[Ww]ithdrawal [Ff]unction|[Ww]ithdraw [Ff]rom [Cc]ontract|[Dd]istance [Cc]ontract'; then
+  finding high "BOTH-WITHDRAWAL-BUTTON-MISSING" "Prominent contract withdrawal button or function missing for EU consumer contracts" "Add a prominent, dedicated, and easily accessible withdrawal button or function on the user interface, allowing consumers to withdraw from contracts/subscriptions within 14 days."
+fi
 # fastlane precheck derived metadata checks
 if grep_has 'coming soon|coming-soon|will be available|in a future update|stay tuned'; then
   finding medium "APPLE-2.3-FUTURE-FUNCTIONALITY" "Future functionality language found (coming soon, beta)" "Describe only what the build does today (fastlane precheck future_functionality, Apple 2.3.1)."

--- a/data/detection-recipes.json
+++ b/data/detection-recipes.json
@@ -73,6 +73,8 @@
     "ANDROID-ACCESSIBILITY-FONTSCALING": "python3 scripts/accessibility-audit.py . --rule ANDROID-ACCESSIBILITY-FONTSCALING",
     "ANDROID-ACCESSIBILITY-HIGHCONTRAST": "python3 scripts/accessibility-audit.py . --rule ANDROID-ACCESSIBILITY-HIGHCONTRAST",
     "ANDROID-ACCESSIBILITY-SCANNER": "python3 scripts/accessibility-audit.py . --rule ANDROID-ACCESSIBILITY-SCANNER",
-    "BOTH-SUBSCRIPTION-HARD-CANCEL": "grep -rniE 'subscri(be|ption)|auto.renew|membership' --include='*.swift' --include='*.kt' --include='*.java' --include='*.html' --include='*.md' . 2>/dev/null | grep -iE 'call.{0,25}cancel|cancel.{0,25}call|mail.{0,25}cancel|write.{0,25}cancel|cancel.{0,15}(in.person|by.phone|by.mail)'"
+    "BOTH-SUBSCRIPTION-HARD-CANCEL": "grep -rniE 'subscri(be|ption)|auto.renew|membership' --include='*.swift' --include='*.kt' --include='*.java' --include='*.html' --include='*.md' . 2>/dev/null | grep -iE 'call.{0,25}cancel|cancel.{0,25}call|mail.{0,25}cancel|write.{0,25}cancel|cancel.{0,15}(in.person|by.phone|by.mail)'",
+    "BOTH-E-EVIDENCE-COMPLIANCE-MISSING": "grep -rniE 'e-evidence|european production order|european preservation order|emergency data production' . 2>/dev/null",
+    "BOTH-WITHDRAWAL-BUTTON-MISSING": "grep -rniE 'withdrawal button|withdrawal function|withdraw from contract|distance contract' . 2>/dev/null"
   }
 }

--- a/data/regulatory-deadlines.json
+++ b/data/regulatory-deadlines.json
@@ -434,6 +434,30 @@
       "enforcement_date": "2025-03-19",
       "affected_repository_sections": "docs/PLATFORM-MECHANICS-2026.md section 3.2, references/rules/android.md",
       "priority": "critical"
+    },
+    {
+      "id": "EU-E-EVIDENCE-REGULATION",
+      "jurisdiction": "European Union (EU)",
+      "law": "e-Evidence Package, Regulation (EU) 2023/1543",
+      "requirement": "Cross-border law enforcement direct electronic evidence access (10 days response timeline, and a critical 8-hour emergency timeline).",
+      "effective_date": "2023-08-18",
+      "grace_period": "36 months",
+      "mandatory_date": "2026-08-18",
+      "enforcement_date": "2026-08-18",
+      "affected_repository_sections": "docs/EU-REGULATORY-2026.md section 5, references/rules/privacy.md",
+      "priority": "high"
+    },
+    {
+      "id": "EU-WITHDRAWAL-BUTTON-DIRECTIVE",
+      "jurisdiction": "European Union (EU)",
+      "law": "Distance Marketing of Financial Services, Directive (EU) 2023/2673",
+      "requirement": "Prominent, easily accessible 'withdrawal button' or 'withdrawal function' on the online interface (including apps) to withdraw from contracts.",
+      "effective_date": "2023-11-28",
+      "grace_period": "30 months",
+      "mandatory_date": "2026-06-19",
+      "enforcement_date": "2026-06-19",
+      "affected_repository_sections": "docs/EU-REGULATORY-2026.md section 5, references/rules/payments.md",
+      "priority": "high"
     }
   ]
 }

--- a/data/rejection-patterns.json
+++ b/data/rejection-patterns.json
@@ -1261,6 +1261,40 @@
         "visit a store to cancel"
       ],
       "fix": "Provide a self-service cancellation path (in-app button or account-settings web page) that is at least as easy as sign-up. Never require a phone call, a mailed letter, or an in-person visit to cancel a subscription billed outside the app stores' own billing."
+    },
+    {
+      "id": "BOTH-E-EVIDENCE-COMPLIANCE-MISSING",
+      "platform": "both",
+      "guideline": "Regulation (EU) 2023/1543 & Directive (EU) 2023/1544 (EU e-Evidence Package)",
+      "title": "Missing legal representative or emergency data-production response procedures for the EU e-Evidence Package",
+      "severity": "high",
+      "detection": "Apps/services processing user data in the EU that fail to designate a legal representative or lack internal procedures to respond to European Production/Preservation Orders within 10 days (or 8 hours for emergencies).",
+      "signals": [
+        "e-Evidence",
+        "European Production Order",
+        "European Preservation Order",
+        "emergency data production",
+        "law enforcement request",
+        "legal representative"
+      ],
+      "fix": "Designate an establishment or appoint a legal representative in the EU, notify contact details by August 18, 2026, and establish internal protocols to deliver user data securely within 8 hours in emergency situations."
+    },
+    {
+      "id": "BOTH-WITHDRAWAL-BUTTON-MISSING",
+      "platform": "both",
+      "guideline": "Apple Guideline 3.1.2, Directive (EU) 2023/2673 Distance Marketing of Financial Services Directive",
+      "title": "Prominent contract withdrawal button or function missing for EU consumer contracts",
+      "severity": "high",
+      "detection": "Apps offering digital subscriptions or distance contracts to EU consumers that fail to provide a prominent, easily accessible 'withdrawal button' or 'withdrawal function' on their online user interface to cancel/withdraw within 14 days.",
+      "signals": [
+        "withdrawal button",
+        "withdrawal function",
+        "withdraw from contract",
+        "distance contract withdrawal",
+        "revoke contract",
+        "cancel subscription"
+      ],
+      "fix": "Add a prominent, dedicated, and easily accessible withdrawal button or function on the user interface, allowing consumers to withdraw from contracts/subscriptions without undue friction."
     }
   ]
 }

--- a/docs/EU-REGULATORY-2026.md
+++ b/docs/EU-REGULATORY-2026.md
@@ -164,6 +164,31 @@ These map onto the Apple accessibility discipline the setup already carries (Dyn
 - DSA protection of minors and age verification. Commission Guidelines on Protection of Minors published 14 July 2025. an EU age-verification blueprint became feature-ready 15 April 2026, with Member States urged to roll out by 31 December 2026.
 - GDPR children's data. EDPB Statement 1/2025 on age assurance (adopted 11 February 2025) sets ten principles, and age assurance must still respect data minimisation and purpose limitation.
 
+### 5.1 EU e-Evidence Package (Regulation (EU) 2023/1543 & Directive (EU) 2023/1544) (HARD, NEW)
+
+The EU e-Evidence Package fundamentally reshapes cross-border law enforcement access to electronic data by allowing judicial authorities of one Member State to directly compel service providers in another Member State to preserve or produce data, bypassing traditional mutual legal assistance frameworks.
+
+- **Scope:** Applies to electronic communications service providers (instant messaging, VoIP, email), internet domain registries, and other information society services that facilitate intra-user communication (such as online marketplaces) or store/process data on behalf of users (such as cloud hosting and SaaS applications). This applies to any provider offering services in the EU, regardless of where they are headquartered.
+- **Key Obligations:**
+  - **Designation/Appointment of Addressees:** Under Directive (EU) 2023/1544, EU-established service providers must designate an establishment, and non-EU-established service providers must appoint a legal representative in the EU, to receive and execute European Production and Preservation Orders.
+  - **Notification Requirement:** Providers must notify the designated central authority of their representative's details and languages. The notification deadline is **18 August 2026**, or within six months of commencing services in the EU.
+  - **European Production Order Execution:** Compels providers to produce electronic evidence. The default compliance window is **10 days**, but in critical emergency situations, providers MUST produce the requested data within **8 hours**.
+  - **European Preservation Order Execution:** Compels providers to preserve electronic evidence for **60 days** to prevent deletion.
+- **Penalties:** Joint and several liability applies to the provider and their designated legal representative. Non-compliance can result in administrative fines of up to **2% of the provider's total annual global turnover** under national implementing legislation.
+- **Sources:** [Regulation (EU) 2023/1543 (EUR-Lex)](https://eur-lex.europa.eu/eli/reg/2023/1543/oj), [Directive (EU) 2023/1544 (EUR-Lex)](https://eur-lex.europa.eu/eli/dir/2023/1544/oj), [Bird & Bird EU e-Evidence Package Guide](https://www.twobirds.com/en/insights/2026/germany/e-evidence-richtlinie-umsetzungsfrist-abgelaufen--implementierungsstatus-und-handlungsbedarf).
+
+### 5.2 EU Contract Withdrawal Button (Distance Marketing of Financial Services Directive (EU) 2023/2673) (HARD, NEW)
+
+The Distance Marketing of Financial Services Directive introduces amendments to the Consumer Rights Directive (Directive 2011/83/EU), ensuring that consumers can easily exercise their statutory right of withdrawal from online contracts.
+
+- **Scope:** Applies to all distance contracts concluded via an online user interface, including websites and mobile applications, that offer retail financial services or other consumer contracts and subscriptions.
+- **Key Obligations:**
+  - **Withdrawal Button/Function:** Service providers must ensure that where a contract is concluded online, consumers can withdraw from it via a prominent, dedicated, and easily accessible "withdrawal button" or "withdrawal function" on the online interface.
+  - **Frictionless Experience:** The cancellation/withdrawal path must be direct and cannot be buried behind multiple steps, contact forms, phone calls, or administrative obstacles. It must be at least as simple as the contract sign-up/subscription process.
+  - **Information Requirements:** The interface must clearly state the 14-day statutory withdrawal period and outline the consequences of withdrawal.
+- **Timelines:** Member States are expected to transpose and implement these requirements by **19 June 2026**.
+- **Sources:** [Directive (EU) 2023/2673 (EUR-Lex)](https://eur-lex.europa.eu/eli/dir/2023/2673/oj), [Reed Smith 2026 EU Regulations Overview](https://www.reedsmith.com/our-insights/blogs/viewpoints/102lyiv/2026-update-eu-regulations-for-tech-and-online-businesses/).
+
 Sources. [Morgan Lewis Data Act](https://www.morganlewis.com/blogs/sourcingatmorganlewis/2025/09/eu-data-act-begins-september-12-impacting-cloud-services-connected-products-and-other-data-industries), [Commission Cyber Resilience Act](https://digital-strategy.ec.europa.eu/en/policies/cyber-resilience-act), [Commission age verification](https://digital-strategy.ec.europa.eu/en/policies/eu-age-verification).
 
 ## 6. Apple platform changes 2025 and 2026 (beyond the base map)
@@ -196,6 +221,8 @@ These are Apple App Review and App Store Connect changes, layered on top of the 
 | DMA external purchase | Entitlement declared, disclosure sheet wired, no IAP mix, reporting wired | live |
 | Notarization | Any non-App-Store build notarized | live |
 | Xcode 26 SDK | Build with Xcode 26 and the iOS 26 SDK | deadline 28 Apr 2026 |
+| EU e-Evidence Package | Legal representative designated and 8-hour emergency response protocol established | 18 Aug 2026 |
+| EU Contract Withdrawal | Prominent, Frictionless contract withdrawal button on user interface | 19 Jun 2026 |
 
 ## 8. Sources
 

--- a/references/README.md
+++ b/references/README.md
@@ -6,9 +6,9 @@ A structured, AI loadable reference tree. Load the rule category and the app typ
 
 - [rules/metadata.md](rules/metadata.md). Metadata and store listing. 9 rules
 - [rules/privacy.md](rules/privacy.md). Privacy and data. 14 rules
-- [rules/payments.md](rules/payments.md). Payments, in app purchase, subscriptions. 7 rules
+- [rules/payments.md](rules/payments.md). Payments, in app purchase, subscriptions. 8 rules
 - [rules/design.md](rules/design.md). Design and login. 3 rules
-- [rules/performance.md](rules/performance.md). Performance and completeness. 21 rules
+- [rules/performance.md](rules/performance.md). Performance and completeness. 22 rules
 - [rules/entitlements.md](rules/entitlements.md). Entitlements. 1 rules
 - [rules/safety.md](rules/safety.md). Safety and user generated content. 2 rules
 - [rules/android.md](rules/android.md). Google Play specific. 22 rules

--- a/references/rules/payments.md
+++ b/references/rules/payments.md
@@ -1,6 +1,6 @@
 # Rules. Payments, in app purchase, subscriptions
 
-7 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
+8 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
 
 ## APPLE-3.1.1-EXTERNAL-PAYMENT
 
@@ -114,4 +114,20 @@ How to detect.
 
 ```bash
 grep -rniE 'subscri(be|ption)|auto.renew|membership' --include='*.swift' --include='*.kt' --include='*.java' --include='*.html' --include='*.md' . 2>/dev/null | grep -iE 'call.{0,25}cancel|cancel.{0,25}call|mail.{0,25}cancel|write.{0,25}cancel|cancel.{0,15}(in.person|by.phone|by.mail)'
+```
+
+## BOTH-WITHDRAWAL-BUTTON-MISSING
+
+- Title. Prominent contract withdrawal button or function missing for EU consumer contracts
+- Platform. both
+- Guideline or policy. Apple Guideline 3.1.2, Directive (EU) 2023/2673 Distance Marketing of Financial Services Directive
+- Severity. high
+- What triggers it. Apps offering digital subscriptions or distance contracts to EU consumers that fail to provide a prominent, easily accessible 'withdrawal button' or 'withdrawal function' on their online user interface to cancel/withdraw within 14 days.
+- How to fix it. Add a prominent, dedicated, and easily accessible withdrawal button or function on the user interface, allowing consumers to withdraw from contracts/subscriptions without undue friction.
+- Detection signals. withdrawal button, withdrawal function, withdraw from contract, distance contract withdrawal, revoke contract, cancel subscription
+
+How to detect.
+
+```bash
+grep -rniE 'withdrawal button|withdrawal function|withdraw from contract|distance contract' . 2>/dev/null
 ```

--- a/references/rules/performance.md
+++ b/references/rules/performance.md
@@ -1,6 +1,6 @@
 # Rules. Performance and completeness
 
-21 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
+22 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
 
 ## APPLE-2.1-MISSING-DEMO-ACCOUNT
 
@@ -238,6 +238,22 @@ How to detect.
 
 ```bash
 grep -rn 'CFBundleURLSchemes\|android:scheme' . && ! grep -rn 'apple-app-site-association\|assetlinks.json' .
+```
+
+## BOTH-E-EVIDENCE-COMPLIANCE-MISSING
+
+- Title. Missing legal representative or emergency data-production response procedures for the EU e-Evidence Package
+- Platform. both
+- Guideline or policy. Regulation (EU) 2023/1543 & Directive (EU) 2023/1544 (EU e-Evidence Package)
+- Severity. high
+- What triggers it. Apps/services processing user data in the EU that fail to designate a legal representative or lack internal procedures to respond to European Production/Preservation Orders within 10 days (or 8 hours for emergencies).
+- How to fix it. Designate an establishment or appoint a legal representative in the EU, notify contact details by August 18, 2026, and establish internal protocols to deliver user data securely within 8 hours in emergency situations.
+- Detection signals. e-Evidence, European Production Order, European Preservation Order, emergency data production, law enforcement request, legal representative
+
+How to detect.
+
+```bash
+grep -rniE 'e-evidence|european production order|european preservation order|emergency data production' . 2>/dev/null
 ```
 
 ## APPLE-ACCESSIBILITY-VOICEOVER

--- a/scripts/monitor-regulatory.py
+++ b/scripts/monitor-regulatory.py
@@ -422,6 +422,65 @@ REGULATORY_TRACKS = {
         ],
         "compliance_impact": "Critical",
     },
+    "EU e-Evidence Package": {
+        "jurisdiction": "European Union",
+        "authorities": ["European Commission", "Official Journal", "EUR-Lex"],
+        "citations": [
+            "Regulation (EU) 2023/1543 on European Production and Preservation Orders for electronic evidence",
+            "Directive (EU) 2023/1544 on harmonised rules on the designation of designated establishments and the appointment of legal representatives"
+        ],
+        "keywords": [
+            "e-evidence",
+            "european production order",
+            "european preservation order",
+            "emergency data production",
+            "law enforcement request",
+            "legal representative",
+        ],
+        "patterns": [
+            r"e-evidence",
+            r"european[ -]production[ -]order",
+            r"european[ -]preservation[ -]order",
+        ],
+        "detect_files": ["*.swift", "*.py", "*.js", "*.ts", "*.json", "*.md"],
+        "detect_regex": r"e-evidence|european production order|european preservation order|emergency data production",
+        "impact_desc": "The EU e-Evidence Package mandates direct cross-border production and preservation of electronic evidence, requiring legal representatives and an 8-hour turnaround for emergency requests.",
+        "migration_steps": [
+            "Designate an establishment or appoint an official legal representative in the EU.",
+            "Formulate and notify the designated Member State authority of representative details by August 18, 2026.",
+            "Establish secure internal processes to execute European Production/Preservation Orders within 10 days, and within 8 hours for critical emergencies."
+        ],
+        "compliance_impact": "High",
+    },
+    "EU Contract Withdrawal Button": {
+        "jurisdiction": "European Union",
+        "authorities": ["European Commission", "Official Journal", "EUR-Lex"],
+        "citations": [
+            "Directive (EU) 2023/2673 amending Directive 2011/83/EU as regards distance contracts for financial services"
+        ],
+        "keywords": [
+            "withdrawal button",
+            "withdrawal function",
+            "withdraw from contract",
+            "distance contract withdrawal",
+            "revoke contract",
+            "cancel subscription",
+        ],
+        "patterns": [
+            r"withdrawal[ -]button",
+            r"withdrawal[ -]function",
+            r"withdraw[ -]from[ -]contract",
+        ],
+        "detect_files": ["*.swift", "*.py", "*.js", "*.ts", "*.json", "*.md"],
+        "detect_regex": r"withdrawal button|withdrawal function|withdraw from contract|distance contract",
+        "impact_desc": "The Distance Marketing Directive requires service providers to implement a prominent and frictionless withdrawal button/function on online interfaces (websites and apps) for consumer contracts concluded online.",
+        "migration_steps": [
+            "Add a prominent and easily accessible 'withdrawal button' or 'withdrawal function' on the subscription or settings interface.",
+            "Ensure the cancellation/withdrawal path is frictionless, self-service, and direct, without requiring phone calls or letters.",
+            "Display clear notices regarding the 14-day statutory right of withdrawal."
+        ],
+        "compliance_impact": "High",
+    },
 }
 
 # Pre-defined Simulated Regulatory Announcements
@@ -431,6 +490,18 @@ SIMULATED_DEVELOPMENTS = [
         "description": "The European Commission published draft implementation guidelines on transparency obligations under Article 50 of the AI Act. Developers of chatbot systems and synthetic content generators must implement interaction disclosure and watermarking.",
         "pubDate": "Fri, 08 May 2026 12:00:00 GMT",
         "link": "https://digital-strategy.ec.europa.eu/en/library/draft-guidelines-implementation-transparency-obligations-certain-ai-systems-under-article-50-ai-act",
+    },
+    {
+        "title": "Transposition and Implementation of the EU e-Evidence Package (Regulation 2023/1543)",
+        "description": "EU Member States have completed transposition of Directive 2023/1544, and Regulation 2023/1543 is directly applicable starting August 2026, requiring designate legal representatives and 8-hour response windows for emergency data requests.",
+        "pubDate": "Sun, 28 Jun 2026 12:00:00 GMT",
+        "link": "https://eur-lex.europa.eu/eli/reg/2023/1543/oj",
+    },
+    {
+        "title": "Distance Marketing of Financial Services Directive requirements for Withdrawal Buttons on online interfaces",
+        "description": "Directive 2023/2673 requires that any distance contracts concluded online must feature an easily accessible and frictionless withdrawal button on the interface by June 2026.",
+        "pubDate": "Fri, 15 May 2026 12:00:00 GMT",
+        "link": "https://eur-lex.europa.eu/eli/dir/2023/2673/oj",
     },
     {
         "title": "FTC issues final updates to the COPPA Children's Online Privacy Rule",


### PR DESCRIPTION
This PR introduces comprehensive support, tracking, documentation, and pre-submission guards for two high-impact European Union compliance requirements taking effect in 2026:

1. **The EU e-Evidence Package (Regulation (EU) 2023/1543 & Directive (EU) 2023/1544):** Requires data-processing services to designate a legal representative in the EU and establishes procedures to respond to European Production/Preservation Orders (within 10 days default, or 8 hours for critical emergencies). Non-compliance carries fines up to 2% of total annual global turnover.
2. **The EU Contract Withdrawal Button Directive (Distance Marketing of Financial Services Directive (EU) 2023/2673):** Mandates online consumer and subscription contracts feature a prominent, easily accessible, frictionless withdrawal button on online user interfaces (including apps and websites).

These tracks are fully mapped and integrated into the global monitor script, pre-submission compliance guard hook, and the App Store Compliance Playbook taxonomy with absolutely zero emojis used.

---
*PR created automatically by Jules for task [10075749663033979155](https://jules.google.com/task/10075749663033979155) started by @mjmirza*