### PR TITLE
Exclude release readiness report from affected files scan

### DIFF
--- a/scripts/release-audit.py
+++ b/scripts/release-audit.py
@@ -282,6 +282,7 @@ def find_affected_files(target_dir, patterns_dict):
                             "rejection-patterns.json" not in rel_path
                             and "release-audit.py" not in rel_path
                             and "app-store-compliance-guard.sh" not in rel_path
+                            and "RELEASE-READINESS-REPORT.md" not in rel_path
                         ):
                             affected[pid].append(rel_path)
 


### PR DESCRIPTION
This PR improves the release readiness compliance scanner so that the output report itself is excluded from the list of programmatically detected affected files, preventing circular references in the violation lists.

---
*PR created automatically by Jules for task [13269318282855207725](https://jules.google.com/task/13269318282855207725) started by @mjmirza*