### PR TITLE
Add Apple developer news landing page to citation allowlist

### DIFF
--- a/.citation-allowlist
+++ b/.citation-allowlist
@@ -19,3 +19,6 @@ https://www.esafety.gov.au/about-us/industry-regulation/social-media-age-restric
 
 # Fixture app domain used by metadata-audit-test.sh.
 https://lumina.app/privacy
+
+# Real landing page flagged as fabricated due to Apple's soft-404 behavior.
+https://developer.apple.com/news/


### PR DESCRIPTION
This submission resolves a false-positive fabrication check in verify-citations.py by adding the canonical Apple developer news landing page (https://developer.apple.com/news/) to the citation allowlist. The check flagged the URL due to Apple's soft-404 behavior, which returns a generic index page with identical fingerprints for non-existent IDs. Allowing the landing page ensures compliance monitoring runs without false positives. All test suites and compliance guards remain completely verified and green.

---
*PR created automatically by Jules for task [8340103226431819893](https://jules.google.com/task/8340103226431819893) started by @mjmirza*