### PR TITLE
docs(regulatory) gap report across six EU and US frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ python3 scripts/deadline-checker.py
 | `docs/PLATFORM-MECHANICS-2026.md` | The platform-mechanics and newer-policy hard rules with dated sources. macOS notarization, Guideline 4.2 and 4.3 with the June 2026 saturation tightening, reader-app entitlement, France ANSSI encryption, visionOS and watchOS and tvOS specifics, plus Android developer verification, Foreground Service types, Play Integrity, Play Billing v8, target API, Health Connect, and the cross-cutting CSAM, UGC, accessibility, sanctions, and PCI items |
 | `docs/BY-APP-TYPE.md` | The rejection map routed by app type. Universal, subscriptions, social, kids, health, games, macOS, AI, crypto and finance, VPN |
 | `docs/COMPETITIVE-GAP-ANALYSIS.md` | A survey of the other open source compliance repositories, what each publishes and why, the gaps they surfaced, and what was folded in here |
+| `docs/REGULATORY-GAP-REPORT-2026.md` | Global and regional regulatory compliance gap analysis prepared by the Senior Compliance Officer, evaluating modern and upcoming frameworks |
 | `docs/OPEN-SOURCE-PATTERNS.md` | What the community already codified. The fastlane precheck metadata rule set, the Android Play Policy Insights and security lints, community rejection repositories, and the Google Play pre-launch report, folded in |
 | `docs/OTHER-STORES.md` | Huawei AppGallery, the Chinese stores, Samsung, Amazon, Microsoft, and RuStore, plus the cross store patterns worth adopting |
 | `docs/GAMBLING-MATRIX.md` | Per country loot box and real money gambling rules, for games that ship worldwide |

--- a/docs/REGULATORY-GAP-REPORT-2026.md
+++ b/docs/REGULATORY-GAP-REPORT-2026.md
@@ -1,12 +1,12 @@
 # Global and Regional Regulatory Compliance Gap Report (2026)
 
-This compliance report is prepared by the Senior Compliance Officer to proactively monitor, evaluate, and analyze the global regulatory landscape. In the ever-evolving regulatory environment, maintaining our organization's integrity and effectiveness requires systematic identification of updates, changes, and compliance gaps.
+This report audits the playbook itself. It takes six regulations that bind app developers shipping into the EU and the US, and checks honestly how far this repository already carries each one, what it only mentions in passing, and what it does not cover at all.
 
-This report evaluates six major modern and upcoming regulatory frameworks, assessing our current repository assets, requirements database, checklists, and automated guard scripts. To ensure continuous compliance and absolute accountability, every identified gap is systematically classified across eight compliance categories: policy, documentation, code, disclosure, logging, testing, evidence, and audit trail.
+Read it as a work list for the playbook, not as legal advice for your company. Where it says something is missing, it means missing from this repository. Each framework is checked across eight angles, which are policy, documentation, code, disclosure, logging, testing, evidence, and audit trail.
 
-## Source Trust Hierarchy and Methodology
+## Source trust hierarchy and methodology
 
-All analysis and cited legal frameworks within this report adhere to the strict Source Trust Hierarchy:
+All analysis and cited legal frameworks within this report adhere to the strict source trust hierarchy.
 - Priority 1 (Official Primary): European Commission, EUR-Lex, Official Journal of the European Union, ENISA, EDPB, FTC, NIST, CISA, ICO, and official government publications.
 - Priority 2 (Reputable News Agencies): Reuters, AP (Associated Press), Bloomberg.
 - Priority 3 (Academic Publications): Academic papers and peer-reviewed journals.
@@ -29,7 +29,7 @@ Official Citation: Regulation (EU) 2023/988 of the European Parliament and of th
 ### 1.2 Comprehensive Gap Analysis Across the Eight Compliance Categories
 
 - **Missing Policy:**
-  There is no formal, written organizational policy regarding GPSR compliance. The organization lacks clear governance on identifying when consumer-facing products or online listings fall within the scope of Regulation (EU) 2023/988.
+  The playbook gives a developer no way to decide whether their listing falls inside Regulation (EU) 2023/988, and no template policy to hand a client who asks.
 - **Missing Documentation:**
   The repository is missing specific developer checklists, guides, or instructional manuals on how to structure online product listings to display GPSR-mandated safety warnings, manufacturer details, and technical instructions.
 - **Missing Code:**
@@ -65,7 +65,7 @@ Official Citation: Regulation (EU) 2023/1543 and Directive (EU) 2023/1544 of the
 ### 2.2 Comprehensive Gap Analysis Across the Eight Compliance Categories
 
 - **Missing Policy:**
-  The organization lacks a formal Law Enforcement Request Policy. There is no corporate governance designating who has the authority to receive, verify, and execute incoming judicial orders from EU authorities.
+  The playbook carries no template Law Enforcement Request Policy, so a small team receiving an EU judicial order has nothing to start from and no guidance on who may act on it.
 - **Missing Documentation:**
   While the repository mentions the e-Evidence Package in general, it lacks concrete operational instructions, runbooks, or detailed manuals for handling 10-day standard orders and 8-hour emergency orders.
 - **Missing Code:**
@@ -92,16 +92,18 @@ Official Citation: Regulation (EU) 2023/1543 and Directive (EU) 2023/1544 of the
 ## 3. EU Contract Withdrawal Button
 
 ### 3.1 Regulatory Overview and Background
-The Distance Marketing of Financial Services Directive (EU) 2023/2673 introduces crucial amendments to the Consumer Rights Directive (Directive 2011/83/EU). It mandates that for any consumer contract or subscription concluded online or through a mobile application within the EU, the service provider must offer a prominent, easily accessible, and frictionless "withdrawal button" or "withdrawal function".
+The Distance Marketing of Financial Services Directive (EU) 2023/2673 amends the Consumer Rights Directive (Directive 2011/83/EU). It requires a prominent, easily accessible withdrawal button or withdrawal function on the online interface for distance contracts for financial services concluded by electronic means.
 
-The statutory withdrawal period is 14 days from the conclusion of the contract or the delivery of goods. The cancellation path must be direct, clear, and at least as simple as the contract sign-up or subscription process. Member States are required to transpose and apply these rules starting 19 June 2026.
+Scope matters here, and it is easy to overstate. The withdrawal button obligation in this Directive attaches to distance financial services contracts, not to every consumer subscription. A general withdrawal button across all distance contracts has been proposed at EU level but is not yet law. Treat it as binding today if your app sells insurance, credit, payment, investment, or another financial service into the EU, and as a strong design default otherwise, since Apple already requires an easy in-app cancellation path regardless.
+
+The statutory withdrawal period is 14 days from the conclusion of the contract. The cancellation path must be direct, clear, and at least as simple as the sign-up path. Member States apply these rules from 19 June 2026.
 
 Official Citation: Directive (EU) 2023/2673 of the European Parliament and of the Council of 22 November 2023.
 
 ### 3.2 Comprehensive Gap Analysis Across the Eight Compliance Categories
 
 - **Missing Policy:**
-  There is no written corporate policy regarding consumer withdrawal rights under EU Directive (EU) 2023/2673. The business has not formalized rules on handling 14-day frictionless cancellations or refund processing.
+  The playbook carries no template policy for the 14 day withdrawal right, and no guidance separating apps that genuinely fall in scope from those adopting it as a design default.
 - **Missing Documentation:**
   The repository does not provide UI design guidelines or checklists specifying the placement, size, prominence, and terminology required to make the withdrawal button compliant with EU expectations.
 - **Missing Code:**
@@ -137,7 +139,7 @@ Official Citations: Utah SB 142 (2025), Texas SB 2420 (2025), Louisiana HB 570 (
 ### 4.2 Comprehensive Gap Analysis Across the Eight Compliance Categories
 
 - **Missing Policy:**
-  The organization has not established a state-specific Children and Minors Privacy Policy that details how the company identifies users from Utah, Texas, Louisiana, or Alabama, or how minor accounts are managed.
+  The playbook has no template minors policy showing how to detect a user in Utah, Texas, Louisiana, or Alabama, and how to handle a minor account once detected.
 - **Missing Documentation:**
   The checklists in `docs/PRE-SUBMISSION-CHECKLIST.md` lack precise, step-by-step developer guidelines for integrating Apple's Declared Age Range API and Google's Play Age Signals API within the same multi-platform project.
 - **Missing Code:**
@@ -173,11 +175,11 @@ Official Citation: Regulation (EU) 2024/1689, Article 4.
 ### 5.2 Comprehensive Gap Analysis Across the Eight Compliance Categories
 
 - **Missing Policy:**
-  There is no written AI Literacy and Training Policy in place. The organization has not defined what constitutes a "sufficient" level of AI literacy for engineers, product managers, or content moderators.
+  The playbook carries no template AI literacy policy, and nothing that helps a small team judge what counts as a sufficient level under Article 4.
 - **Missing Documentation:**
   The repository lacks developer-facing documentation or checklists explaining the team's obligations under Article 4 or how to stay updated on emerging AI safety and risk evaluation standards.
 - **Missing Code:**
-  (Not applicable for organizational literacy, but we lack internal command-line compliance helper tools to easily verify that developers have logged their required AI literacy credentials prior to committing code).
+  Not applicable, since Article 4 binds people rather than code. A small helper that checks whether a literacy log exists and is current would still be useful.
 - **Missing Disclosure:**
   Public-facing documentation, recruitment materials, or partner contracts do not disclose our commitment to or enforcement of AI literacy standards as mandated by Article 4.
 - **Missing Logging:**
@@ -185,7 +187,7 @@ Official Citation: Regulation (EU) 2024/1689, Article 4.
 - **Missing Testing:**
   There are no automated internal lints, pre-commit hooks, or CLI tools to verify that team members committing AI-related changes have valid, up-to-date literacy records.
 - **Missing Evidence:**
-  The organization lacks compiled evidence of compliance, such as certificates of completion, copies of safety training slide decks, or risk assessment methodologies used in internal training.
+  The playbook has no example of what acceptable evidence looks like, such as a completed training log, a course record, or a written risk assessment.
 - **Missing Audit Trail:**
   There is no historical audit trail documenting when the AI literacy policy was reviewed, when training modules were updated, or how team training records evolved over time.
 
@@ -209,7 +211,7 @@ Official Citation: Regulation (EU) 2024/1689, Article 50.
 ### 6.2 Comprehensive Gap Analysis Across the Eight Compliance Categories
 
 - **Missing Policy:**
-  There is no formal corporate policy governing AI transparency, disclosure timing, or synthetic content watermarking in our AI integrations.
+  The playbook carries no template AI transparency policy covering when disclosure must appear and how generated media should be marked.
 - **Missing Documentation:**
   The checklists in `docs/PRE-SUBMISSION-CHECKLIST.md` mention Article 50 but lack detailed, technical, developer-facing instructions on how to implement machine-readable watermarking or deepfake disclosures.
 - **Missing Code:**
@@ -235,21 +237,41 @@ Official Citation: Regulation (EU) 2024/1689, Article 50.
 
 ## 7. Consolidated Gap Classification Matrix
 
-This matrix summarizes the missing compliance elements identified across all six regulatory frameworks, mapped to the eight compliance domains.
+Where the playbook already covers a framework, the cell says Covered. Partial means the rule is named with a dated source but a developer still has no step by step way to satisfy it. Missing means the playbook does not carry it at all.
 
-| Regulatory Framework | Policy | Documentation | Code | Disclosure | Logging | Testing | Evidence | Audit Trail |
+| Regulatory framework | Policy | Documentation | Code | Disclosure | Logging | Testing | Evidence | Audit trail |
 |---|---|---|---|---|---|---|---|---|
 | **EU GPSR** | Missing | Missing | Missing | Missing | Missing | Missing | Missing | Missing |
-| **EU e-Evidence** | Missing | Missing | Missing | Missing | Missing | Missing | Missing | Missing |
-| **EU Withdrawal** | Missing | Missing | Missing | Missing | Missing | Missing | Missing | Missing |
-| **US State ASAA** | Missing | Missing | Missing | Missing | Missing | Missing | Missing | Missing |
-| **EU AI Act Art 4**| Missing | Missing | N/A | Missing | Missing | Missing | Missing | Missing |
-| **EU AI Act Art 50**| Missing | Missing | Missing | Missing | Missing | Missing | Missing | Missing |
+| **EU e-Evidence** | Partial | Covered | Missing | Partial | Missing | Missing | Missing | Missing |
+| **EU withdrawal button** | Partial | Covered | Missing | Partial | Missing | Missing | Missing | Missing |
+| **US state ASAA** | Partial | Covered | Missing | Partial | Missing | Missing | Missing | Missing |
+| **EU AI Act Art 4**| Partial | Covered | N/A | Partial | Missing | Missing | Missing | Missing |
+| **EU AI Act Art 50**| Partial | Covered | Missing | Partial | Missing | Missing | Missing | Missing |
+
+The honest read. Five of the six are already named in `docs/EU-REGULATORY-2026.md`, `docs/GLOBAL-REGULATORY-2026.md`, `data/regulatory-deadlines.json`, and `data/rejection-patterns.json`, with dated sources and a deadline entry. What they lack is the implementation layer, meaning detection rules in the guard, code templates, and tests. GPSR is the only one absent end to end, so it is the first thing to add.
 
 ---
 
 ## 8. Conclusion and Future Monitoring
 
-This global and regional regulatory gap analysis demonstrates that while our repository maintains strong baseline checklists for common App Store and Google Play rejections, substantial compliance gaps exist regarding hard regulatory laws. As a Senior Compliance Officer, the priority is to systematically close these gaps.
+The playbook is strong on what gets an app rejected by a store reviewer, and thinner on the laws that bind the app once it is live. Five of the six frameworks here are already named with dated sources. What is missing is the layer a developer can act on, meaning detection rules the guard can fire on, code templates they can paste, and tests that prove the obligation is met.
 
-Continuous, proactive monitoring of official Priority 1 sources (including EUR-Lex and the FTC) remains essential to maintaining our organizational integrity and compliance effectiveness. All future updates to this report or related automated compliance checks must strictly adhere to our strict emoji-free policy.
+In priority order.
+
+1. Add GPSR, the only framework absent end to end.
+2. Give the five Partial frameworks detection rules in `data/rejection-patterns.json` and checklist items a developer can tick.
+3. Add the code templates, starting with the AI Act Article 50 disclosure line and the withdrawal path, since both carry 2026 deadlines.
+
+This report is a snapshot. It goes stale the moment a deadline moves, so re-run it against EUR-Lex and the other primary sources rather than trusting the dates here on their own.
+
+## 9. Sources
+
+Every regulation named above, at its primary source.
+
+- GPSR, [Regulation (EU) 2023/988](https://eur-lex.europa.eu/eli/reg/2023/988/oj)
+- e-Evidence Regulation, [Regulation (EU) 2023/1543](https://eur-lex.europa.eu/eli/reg/2023/1543/oj)
+- e-Evidence Directive, [Directive (EU) 2023/1544](https://eur-lex.europa.eu/eli/dir/2023/1544/oj)
+- Distance Marketing of Financial Services, [Directive (EU) 2023/2673](https://eur-lex.europa.eu/eli/dir/2023/2673/oj)
+- EU AI Act, [Regulation (EU) 2024/1689](https://eur-lex.europa.eu/eli/reg/2024/1689/oj)
+
+The US state App Store Accountability Acts are cited to their bill texts in [docs/GLOBAL-REGULATORY-2026.md](GLOBAL-REGULATORY-2026.md), which is the source of record for that section rather than this report.

--- a/docs/REGULATORY-GAP-REPORT-2026.md
+++ b/docs/REGULATORY-GAP-REPORT-2026.md
@@ -1,0 +1,255 @@
+# Global and Regional Regulatory Compliance Gap Report (2026)
+
+This compliance report is prepared by the Senior Compliance Officer to proactively monitor, evaluate, and analyze the global regulatory landscape. In the ever-evolving regulatory environment, maintaining our organization's integrity and effectiveness requires systematic identification of updates, changes, and compliance gaps.
+
+This report evaluates six major modern and upcoming regulatory frameworks, assessing our current repository assets, requirements database, checklists, and automated guard scripts. To ensure continuous compliance and absolute accountability, every identified gap is systematically classified across eight compliance categories: policy, documentation, code, disclosure, logging, testing, evidence, and audit trail.
+
+## Source Trust Hierarchy and Methodology
+
+All analysis and cited legal frameworks within this report adhere to the strict Source Trust Hierarchy:
+- Priority 1 (Official Primary): European Commission, EUR-Lex, Official Journal of the European Union, ENISA, EDPB, FTC, NIST, CISA, ICO, and official government publications.
+- Priority 2 (Reputable News Agencies): Reuters, AP (Associated Press), Bloomberg.
+- Priority 3 (Academic Publications): Academic papers and peer-reviewed journals.
+- Priority 4 (Industry Publications): Industry blogs and vendor publications.
+- Priority 5 (Social and Unverified): LinkedIn, Reddit, Twitter, and AI generated summaries.
+
+No Priority 4 or Priority 5 sources are relied upon unless corroborated traceably by Priority 1 publications. In line with repository guidelines, this document is 100% emoji-free and contains no emoticons or graphical symbols of any kind.
+
+---
+
+## 1. EU General Product Safety Regulation (GPSR)
+
+### 1.1 Regulatory Overview and Background
+The EU General Product Safety Regulation (GPSR), Regulation (EU) 2023/988, entered into force on 12 June 2023 and became fully applicable on 13 December 2024. It replaces the old General Product Safety Directive (2001/95/EC) to address the safety challenges of online marketplaces, digital products, and complex supply chains.
+
+The GPSR applies to all non-food consumer products placed on the EU market, both offline and online. For digital systems and software, the GPSR mandates that online marketplaces and e-commerce applications clearly display product safety warnings, instructions, manufacturer and importer identity, and contact details directly on the online interface.
+
+Official Citation: Regulation (EU) 2023/988 of the European Parliament and of the Council of 10 May 2023 on general product safety.
+
+### 1.2 Comprehensive Gap Analysis Across the Eight Compliance Categories
+
+- **Missing Policy:**
+  There is no formal, written organizational policy regarding GPSR compliance. The organization lacks clear governance on identifying when consumer-facing products or online listings fall within the scope of Regulation (EU) 2023/988.
+- **Missing Documentation:**
+  The repository is missing specific developer checklists, guides, or instructional manuals on how to structure online product listings to display GPSR-mandated safety warnings, manufacturer details, and technical instructions.
+- **Missing Code:**
+  The automated compliance guard and detection recipes lack any rules or patterns to scan codebase files for GPSR-related elements. Additionally, mock user interfaces and templates in this repository do not contain code blocks for displaying manufacturer identity or product safety warnings on EU storefronts.
+- **Missing Disclosure:**
+  Online interface templates do not provide placeholder components or guidance for displaying the manufacturer's name, registered trade name or trademark, postal address, and electronic address (such as email or website) as required under Article 19 of the GPSR.
+- **Missing Logging:**
+  There are no architectural provisions or schemas for logging product safety incidents, recalls, or corrective actions. The repository fails to supply templates for a centralized, secure incident log.
+- **Missing Testing:**
+  No automated tests exist to verify that online interface elements dynamically display required product safety information, manufacturer details, or warning notices based on the user's geographic location.
+- **Missing Evidence:**
+  The repository lacks physical templates or examples of compliance evidence, such as Technical Documentation sheets, safety risk assessments, or proof of a designated Responsible Person in the EU.
+- **Missing Audit Trail:**
+  There is no audit trail or historical record system to track when product safety policies were updated, when safety warnings were reviewed, or when corrective measures were implemented in response to a safety alert.
+
+### 1.3 Remediation and Action Plan
+1. Establish a written General Product Safety Policy outlining the designation of an EU-based Responsible Person and product classification criteria.
+2. Incorporate GPSR-specific metadata requirements (manufacturer address, email, product identifier) into `data/rejection-patterns.json` and `docs/PRE-SUBMISSION-CHECKLIST.md`.
+3. Add UI templates in the references directory that demonstrate compliant product detail pages including safety warning labels and electronic contact details.
+4. Integrate an automated test runner script that verifies the presence of safety disclosures prior to app submission.
+
+---
+
+## 2. EU e-Evidence Package
+
+### 2.1 Regulatory Overview and Background
+The EU e-Evidence Package consists of Regulation (EU) 2023/1543 on European Production and Preservation Orders for electronic evidence in criminal matters and Directive (EU) 2023/1544 on the appointment of legal representatives for the purpose of gathering evidence. Adopted in 2023, the mandatory compliance enforcement date is 18 August 2026.
+
+This framework allows judicial authorities of an EU Member State to issue European Production Orders (EPOs) or European Preservation Orders directly to service providers offering services in the EU, regardless of where the provider is headquartered. The default compliance window to produce user data is 10 days, but in critical emergency cases, providers are legally required to produce the requested data within a strict 8-hour timeline.
+
+Official Citation: Regulation (EU) 2023/1543 and Directive (EU) 2023/1544 of the European Parliament and of the Council.
+
+### 2.2 Comprehensive Gap Analysis Across the Eight Compliance Categories
+
+- **Missing Policy:**
+  The organization lacks a formal Law Enforcement Request Policy. There is no corporate governance designating who has the authority to receive, verify, and execute incoming judicial orders from EU authorities.
+- **Missing Documentation:**
+  While the repository mentions the e-Evidence Package in general, it lacks concrete operational instructions, runbooks, or detailed manuals for handling 10-day standard orders and 8-hour emergency orders.
+- **Missing Code:**
+  There are no automated scripts or secure API endpoints in the repository's backend mock implementations to assist in securely exporting, filtering, and packaging user data in response to a valid legal order.
+- **Missing Disclosure:**
+  Public-facing documentation, including Privacy Policies, fails to explicitly disclose to EU users that their data may be preserved or disclosed to European law enforcement in accordance with Regulation (EU) 2023/1543.
+- **Missing Logging:**
+  The repository does not contain database schemas or logging systems designed to track incoming law enforcement requests, verification statuses, data access activities, or data releases.
+- **Missing Testing:**
+  There are no integration tests or validation flows to simulate the rapid 8-hour emergency retrieval and secure packaging of user data under simulated pressure.
+- **Missing Evidence:**
+  The repository is missing verified templates of European Production Order certificates (EPOC) or European Preservation Order certificates (EPOC-PR) for compliance officers to study and verify.
+- **Missing Audit Trail:**
+  A secure, unalterable audit trail system to record every administrative interaction, data extraction, and transmission made by compliance officers during a legal request is completely absent.
+
+### 2.3 Remediation and Action Plan
+1. Draft and implement a comprehensive Law Enforcement Response Protocol that specifically establishes the roles, responsibilities, and secure communication channels for executing EPOs.
+2. Formally designate an EU establishment or legal representative and notify the designated central authority before the 18 August 2026 deadline.
+3. Build secure backend scripts to automate the extraction and encryption of requested user datasets, ensuring execution can occur within the 8-hour emergency window.
+4. Establish a tamper-proof cryptographic audit trail to log all incoming certificates, verification checks, data extractions, and secure transmissions.
+
+---
+
+## 3. EU Contract Withdrawal Button
+
+### 3.1 Regulatory Overview and Background
+The Distance Marketing of Financial Services Directive (EU) 2023/2673 introduces crucial amendments to the Consumer Rights Directive (Directive 2011/83/EU). It mandates that for any consumer contract or subscription concluded online or through a mobile application within the EU, the service provider must offer a prominent, easily accessible, and frictionless "withdrawal button" or "withdrawal function".
+
+The statutory withdrawal period is 14 days from the conclusion of the contract or the delivery of goods. The cancellation path must be direct, clear, and at least as simple as the contract sign-up or subscription process. Member States are required to transpose and apply these rules starting 19 June 2026.
+
+Official Citation: Directive (EU) 2023/2673 of the European Parliament and of the Council of 22 November 2023.
+
+### 3.2 Comprehensive Gap Analysis Across the Eight Compliance Categories
+
+- **Missing Policy:**
+  There is no written corporate policy regarding consumer withdrawal rights under EU Directive (EU) 2023/2673. The business has not formalized rules on handling 14-day frictionless cancellations or refund processing.
+- **Missing Documentation:**
+  The repository does not provide UI design guidelines or checklists specifying the placement, size, prominence, and terminology required to make the withdrawal button compliant with EU expectations.
+- **Missing Code:**
+  The front-end user interface templates and billing mock codes in this repository do not contain any functional implementation of a withdrawal button or withdrawal modal sheet.
+- **Missing Disclosure:**
+  Subscription registration interfaces do not prominently disclose the 14-day statutory right of withdrawal or provide an in-app link explaining the consequences and terms of contract revocation.
+- **Missing Logging:**
+  There are no logging mechanisms designed to capture and record when a user clicks the withdrawal button, the timestamp of the request, the confirmation of contract termination, or the initiation of the refund flow.
+- **Missing Testing:**
+  No automated UI or unit tests exist in the repository to verify that the withdrawal flow can be completed successfully without administrative friction (such as requiring customer service interaction).
+- **Missing Evidence:**
+  The repository lacks templates of withdrawal forms, cancellation confirmation receipts, or standardized documentation to prove compliance in the event of consumer disputes.
+- **Missing Audit Trail:**
+  A systematic audit trail tracking the historical cancellation and refund rates, compliance audits of subscription flows, and updates to the cancellation interface is not implemented.
+
+### 3.3 Remediation and Action Plan
+1. Formulate a Consumer Cancellation and Refund Policy aligned with the Distance Marketing of Financial Services Directive.
+2. Develop a prominent, easily accessible "Withdrawal Button" component within the account settings of all EU-facing subscription templates.
+3. Establish robust logging of cancellation requests, timestamps, and refund transactions in a dedicated database schema.
+4. Implement automated end-to-end UI tests to verify that the withdrawal button executes a frictionless, self-service contract termination without requiring manual human approval.
+
+---
+
+## 4. US State App Store Accountability Acts (ASAA)
+
+### 4.1 Regulatory Overview and Background
+The US State App Store Accountability Acts (ASAA) represent a growing wave of state-level legislation (Utah SB 142, Texas SB 2420, Louisiana HB 570, Alabama HB 161) aimed at regulating minors' access to mobile applications, in-app purchases, and content updates.
+
+These laws place strict operational obligations on both app stores and mobile application developers. Developers must request and process the user's age category (e.g., via Apple's Declared Age Range API or Google's Play Age Signals API) and obtain verifiable parental consent before allowing minors (under 18 or under 16, depending on the state) to download, purchase digital goods, or access major updates. Furthermore, verified age verification data must be deleted immediately after verification to protect children's privacy.
+
+Official Citations: Utah SB 142 (2025), Texas SB 2420 (2025), Louisiana HB 570 (2025), Alabama HB 161 (2026).
+
+### 4.2 Comprehensive Gap Analysis Across the Eight Compliance Categories
+
+- **Missing Policy:**
+  The organization has not established a state-specific Children and Minors Privacy Policy that details how the company identifies users from Utah, Texas, Louisiana, or Alabama, or how minor accounts are managed.
+- **Missing Documentation:**
+  The checklists in `docs/PRE-SUBMISSION-CHECKLIST.md` lack precise, step-by-step developer guidelines for integrating Apple's Declared Age Range API and Google's Play Age Signals API within the same multi-platform project.
+- **Missing Code:**
+  Although the rejection patterns contain entries for state-level laws, the mock client implementations in the codebase do not integrate with `DeclaredAgeRange` or `com.google.android.play:age-signals` to restrict app access dynamically.
+- **Missing Disclosure:**
+  The in-app onboarding flows do not display required state disclosures explaining that the user's age category is requested to comply with state accountability laws and that parental consent is mandatory for minors.
+- **Missing Logging:**
+  There is no secure backend system designed to log the receipt of parental consent, consent revocations (such as the `RESCIND_CONSENT` server notification), or the immediate deletion of raw age-verification documents.
+- **Missing Testing:**
+  The test suites do not include automated integration tests to verify that the application blocks minor accounts from accessing premium features or completing in-app purchases in the absence of valid consent signals.
+- **Missing Evidence:**
+  The repository does not contain templates or examples of parental consent agreements, identity verification logs, or data minimization records to prove compliance to state Attorneys General.
+- **Missing Audit Trail:**
+  An immutable audit trail to record the historical rollout of age-assurance features, changes in consent policies, and records of immediate verification data deletions is entirely absent.
+
+### 4.3 Remediation and Action Plan
+1. Create a detailed written Minor Age Assurance Policy that specifies how state-level requirements are identified and how children's data is strictly minimized.
+2. Implement cross-platform native hooks in the mobile codebases to query Apple's Declared Age Range API and Google's Play Age Signals API during onboarding.
+3. Build database triggers and automated procedures to purge raw age-verification data immediately after the user's age category is confirmed.
+4. Establish automated unit tests that verify that when the age category returns a minor band, in-app billing is disabled until a verifiable parental consent flag is successfully processed.
+
+---
+
+## 5. EU AI Act Article 4 (AI Literacy)
+
+### 5.1 Regulatory Overview and Background
+Article 4 of the EU AI Act (Regulation (EU) 2024/1689) establishes a mandatory requirement for AI literacy. It mandates that any provider or deployer of AI systems (including mobile application developers utilizing third-party generative AI APIs) must take measures to ensure a sufficient level of AI literacy among their staff and other persons dealing with the operation of AI systems.
+
+This requirement applies to all organizations, with no headcount carve-out, meaning small development teams and solo creators are equally bound. The level of literacy required scales with the technical complexity and impact of the AI integration. Pragmatic compliance for a software engineering team requires maintaining a written policy, team induction records, a refresh schedule, and an active training log.
+
+Official Citation: Regulation (EU) 2024/1689, Article 4.
+
+### 5.2 Comprehensive Gap Analysis Across the Eight Compliance Categories
+
+- **Missing Policy:**
+  There is no written AI Literacy and Training Policy in place. The organization has not defined what constitutes a "sufficient" level of AI literacy for engineers, product managers, or content moderators.
+- **Missing Documentation:**
+  The repository lacks developer-facing documentation or checklists explaining the team's obligations under Article 4 or how to stay updated on emerging AI safety and risk evaluation standards.
+- **Missing Code:**
+  (Not applicable for organizational literacy, but we lack internal command-line compliance helper tools to easily verify that developers have logged their required AI literacy credentials prior to committing code).
+- **Missing Disclosure:**
+  Public-facing documentation, recruitment materials, or partner contracts do not disclose our commitment to or enforcement of AI literacy standards as mandated by Article 4.
+- **Missing Logging:**
+  The repository is missing an active, centralized training log or registry to track employee inductions, course completions, and regular literacy refreshers.
+- **Missing Testing:**
+  There are no automated internal lints, pre-commit hooks, or CLI tools to verify that team members committing AI-related changes have valid, up-to-date literacy records.
+- **Missing Evidence:**
+  The organization lacks compiled evidence of compliance, such as certificates of completion, copies of safety training slide decks, or risk assessment methodologies used in internal training.
+- **Missing Audit Trail:**
+  There is no historical audit trail documenting when the AI literacy policy was reviewed, when training modules were updated, or how team training records evolved over time.
+
+### 5.3 Remediation and Action Plan
+1. Draft and publish an internal AI Literacy Policy defining the required competency areas (AI safety, risk assessment, data privacy, bias identification).
+2. Create a centralized `AI_LITERACY_LOG.md` within the repository to track training dates, modules, team member names, and verification methods.
+3. Designate a compliance coordinator to review the team's literacy records on an annual basis.
+4. Set up an automated check in the CI pipeline that warns if the literacy log has not been reviewed or updated within the calendar year.
+
+---
+
+## 6. EU AI Act Article 50 (Transparency Obligations)
+
+### 6.1 Regulatory Overview and Background
+Article 50 of the EU AI Act dictates strict transparency obligations for certain AI systems, taking full legal effect on 2 August 2026. This framework is a critical release blocker for any application incorporating artificial intelligence that reaches users in the European Union.
+
+Under Article 50(1), providers must ensure that AI systems intended to interact directly with natural persons are designed and developed in such a way that those persons are informed that they are interacting with an AI system. Article 50(2) mandates that outputs of generative AI systems (text, audio, images, or video) must be marked in a machine-readable format and detectable as artificially generated or manipulated. Article 50(4) requires deployers of deepfakes to disclose that the content has been artificially generated or manipulated.
+
+Official Citation: Regulation (EU) 2024/1689, Article 50.
+
+### 6.2 Comprehensive Gap Analysis Across the Eight Compliance Categories
+
+- **Missing Policy:**
+  There is no formal corporate policy governing AI transparency, disclosure timing, or synthetic content watermarking in our AI integrations.
+- **Missing Documentation:**
+  The checklists in `docs/PRE-SUBMISSION-CHECKLIST.md` mention Article 50 but lack detailed, technical, developer-facing instructions on how to implement machine-readable watermarking or deepfake disclosures.
+- **Missing Code:**
+  The codebase templates do not include helper classes, middle-tier layers, or utilities to inject in-audible or invisible machine-readable watermarks (such as C2PA metadata) into generated assets.
+- **Missing Disclosure:**
+  Chat and generation UI templates do not display the required immediate disclosure ("You are interacting with an AI system") at the time of the first user exposure.
+- **Missing Logging:**
+  There are no database logging schemas or tracking mechanisms to record that an AI transparency warning was successfully displayed to a specific user session.
+- **Missing Testing:**
+  The existing test runner scripts do not check for the presence of synthetic media markers or verify that generated outputs are machine-detectable as artificially created.
+- **Missing Evidence:**
+  The repository is missing factual evidence of compliance, such as independent security assessments of content moderation filters or proof of metadata retention.
+- **Missing Audit Trail:**
+  An unalterable audit trail recording our technical choices, vendor audits, model changes, and modifications to our transparency disclosures is not maintained.
+
+### 6.3 Remediation and Action Plan
+1. Formulate a corporate AI Transparency and Disclosure Policy that mandates direct disclosure and machine-readable output marking.
+2. Incorporate explicit, prominent notices (such as "You are chatting with an AI assistant") inside all conversational interface templates.
+3. Implement standard metadata injection (using the C2PA specification or cryptographic watermarking) inside all synthetic media generation pipelines.
+4. Establish automated integration tests to scan generated media outputs and verify that the machine-readable compliance headers are properly set and preserved.
+
+---
+
+## 7. Consolidated Gap Classification Matrix
+
+This matrix summarizes the missing compliance elements identified across all six regulatory frameworks, mapped to the eight compliance domains.
+
+| Regulatory Framework | Policy | Documentation | Code | Disclosure | Logging | Testing | Evidence | Audit Trail |
+|---|---|---|---|---|---|---|---|---|
+| **EU GPSR** | Missing | Missing | Missing | Missing | Missing | Missing | Missing | Missing |
+| **EU e-Evidence** | Missing | Missing | Missing | Missing | Missing | Missing | Missing | Missing |
+| **EU Withdrawal** | Missing | Missing | Missing | Missing | Missing | Missing | Missing | Missing |
+| **US State ASAA** | Missing | Missing | Missing | Missing | Missing | Missing | Missing | Missing |
+| **EU AI Act Art 4**| Missing | Missing | N/A | Missing | Missing | Missing | Missing | Missing |
+| **EU AI Act Art 50**| Missing | Missing | Missing | Missing | Missing | Missing | Missing | Missing |
+
+---
+
+## 8. Conclusion and Future Monitoring
+
+This global and regional regulatory gap analysis demonstrates that while our repository maintains strong baseline checklists for common App Store and Google Play rejections, substantial compliance gaps exist regarding hard regulatory laws. As a Senior Compliance Officer, the priority is to systematically close these gaps.
+
+Continuous, proactive monitoring of official Priority 1 sources (including EUR-Lex and the FTC) remains essential to maintaining our organizational integrity and compliance effectiveness. All future updates to this report or related automated compliance checks must strictly adhere to our strict emoji-free policy.


### PR DESCRIPTION
Adds a gap report covering six regulations that bind app developers shipping into the EU and the US, and audits how far the playbook already carries each one. Reworked from the draft in #139.

What changed against that draft.

- Corrected the withdrawal-button scope. Directive (EU) 2023/2673 binds distance financial services contracts, not every consumer subscription. The general button across all distance contracts is still a proposal, not law
- Replaced the all-Missing matrix with an honest Covered, Partial, Missing read. Five of the six frameworks are already carried in EU-REGULATORY-2026, GLOBAL-REGULATORY-2026, and the deadline database. GPSR is the only one absent everywhere
- Rewrote the corporate compliance-officer voice into the playbook's own, so the report reads as a work list for this repository rather than legal advice for the reader's company
- Added a sources section with five EUR-Lex links

Verification.

- `python3 scripts/verify-citations.py --files docs/REGULATORY-GAP-REPORT-2026.md` reports 5 of 5 verified real
- `python3 scripts/validate.py` reports 82 patterns, 75 recipes, 38 deadlines, 0 errors

Suggested labels

- documentation
