### PR TITLE
chore(github) add the missing community health files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Every path is reviewed by the maintainer until other owners are earned.
+* @mjmirza

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+## The short version
+
+Be decent. Argue with the claim, never the person. Bring a source.
+
+## Our pledge
+
+Everyone who takes part in this project, as a contributor or a maintainer, commits to making participation free of harassment for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## What good participation looks like here
+
+- Correcting a wrong guideline number, date, or citation, and showing the source
+- Saying plainly when something is unverified, rather than smoothing over it
+- Accepting a correction without defending the mistake
+- Assuming the other person is trying to get it right
+
+## What is not acceptable
+
+- Personal attacks, insults, or derogatory comments
+- Harassment in public or private, including unwanted contact
+- Publishing someone's private information without their explicit permission
+- Sexualised language or imagery, and unwelcome sexual attention
+- Sustained disruption of discussion
+- Anything else a reasonable professional would recognise as inappropriate
+
+## Scope
+
+This applies in every project space, including issues, pull requests, discussions, and commit history, and anywhere someone is representing the project in public.
+
+## Enforcement
+
+Report anything unacceptable privately to the maintainer through GitHub, or through the contact route in [SECURITY.md](SECURITY.md) if it is sensitive. Reports are handled discreetly and the reporter's identity is protected.
+
+The maintainer may edit, hide, or delete contributions that break this code, and may temporarily or permanently ban an account for repeated or severe behaviour. Where a ban is issued, the reason is stated.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), version 2.1.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: mjmirza

--- a/.github/ISSUE_TEMPLATE/citation-problem.md
+++ b/.github/ISSUE_TEMPLATE/citation-problem.md
@@ -1,0 +1,36 @@
+---
+name: Wrong or stale citation
+about: A guideline number, date, statistic, or link in this playbook is wrong, stale, or dead
+title: "[citation] "
+labels: ["documentation"]
+---
+
+## Where it is
+
+<!-- File and line, or the heading. For example docs/APPLE.md, section 2.1. -->
+
+## What it currently says
+
+<!-- Paste the exact line. -->
+
+## What it should say
+
+<!-- The corrected guideline number, date, statistic, or URL. -->
+
+## Source
+
+<!--
+A primary source. Apple, Google, EUR-Lex, a regulator, a state legislature.
+Paste the URL you actually opened, and quote the sentence that proves it.
+-->
+
+- URL:
+- Quote:
+
+## Type of problem
+
+- [ ] Wrong guideline or policy number
+- [ ] Wrong or outdated date or deadline
+- [ ] Statistic that does not match the source
+- [ ] Dead link, or a link that returns a page that does not contain the claim
+- [ ] Claim with no source at all

--- a/.github/ISSUE_TEMPLATE/tooling-bug.md
+++ b/.github/ISSUE_TEMPLATE/tooling-bug.md
@@ -1,0 +1,37 @@
+---
+name: Guard or monitor bug
+about: A script misfires, crashes, or reports something that is not true
+title: "[bug] "
+labels: ["bug"]
+---
+
+## Which script
+
+<!-- For example agent-os/hooks/app-store-compliance-guard.sh, or scripts/monitor-privacy.py. -->
+
+## What you ran
+
+```
+```
+
+## What it printed
+
+```
+```
+
+## What you expected instead
+
+<!-- Be concrete. "Should not have flagged X", or "should have flagged Y and did not". -->
+
+## Which kind of problem
+
+- [ ] False positive, it flagged something that is fine
+- [ ] False negative, it missed something real
+- [ ] Crash or error
+- [ ] Output that presents simulate-mode sample data as if it were a real announcement
+
+## Environment
+
+- OS:
+- Python version, if a Python script:
+- Project type it ran against, iOS, Android, or both:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+## What this changes
+
+<!-- One or two sentences. What is different after this merges. -->
+
+## Why
+
+<!-- The rejection, the policy change, or the gap this closes. Link the issue if there is one. -->
+
+## Sources
+
+<!--
+Every factual claim needs a primary source. Apple, Google, EUR-Lex, a state
+legislature, a regulator. Paste the URLs you actually opened.
+
+If this PR adds no factual claims, write "none, no new claims".
+-->
+
+- 
+
+## Checks I ran
+
+<!-- Paste the real output, not a tick. A checked box with no output is not evidence. -->
+
+```
+python3 scripts/validate.py
+python3 scripts/verify-citations.py --files docs/ data/
+```
+
+## Declarations
+
+- [ ] Every guideline number, date, and statistic here traces to a source above. Nothing is from memory
+- [ ] No simulate-mode or sample monitor output is committed as if it were a real announcement
+- [ ] This is not a point-in-time generated report. Generated snapshots go stale, the generator is what belongs in the repo
+- [ ] No emoji, and no AI-assistant attribution in the commits
+
+## Anything a reviewer should look at first
+
+<!-- The riskiest part, or the part you are least sure about. Say so plainly. -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## What this repository is, and what it is not
+
+This is a documentation and tooling playbook. It ships Markdown references, JSON data files, shell and Python scripts that read a project and report findings. It does not run a service, hold user data, or handle credentials.
+
+That shapes what counts as a security issue here.
+
+## Supported versions
+
+The default branch is the only supported version. Fixes land on `master` and are not backported.
+
+## Reporting a vulnerability
+
+Report privately through GitHub's [Report a vulnerability](https://github.com/mjmirza/app-store-compliance/security/advisories/new) form. That opens a private advisory visible only to the maintainer.
+
+Do not open a public issue for anything in the first list below.
+
+Expect a first response within 7 days. If a fix is warranted, the advisory stays private until it lands, then it is published with credit unless you ask otherwise.
+
+## Report privately
+
+- Command injection or arbitrary code execution in any script under `scripts/` or `agent-os/hooks/`, for example a path or project name that reaches a shell unquoted
+- Path traversal that lets an audited project write outside its own directory
+- Any way a scanned project can make the guard exfiltrate data or reach the network unexpectedly
+- A supply-chain problem in something the repository tells you to install or run
+- Credentials or tokens committed anywhere in the tree or its history
+
+## Open a normal public issue
+
+- A wrong, stale, or missing guideline reference
+- A rejection pattern that misfires or never fires
+- A broken citation link
+- A false positive or false negative from a monitor
+- Anything about how a policy is worded or explained
+
+Accuracy problems are the most valuable reports this project receives, and they belong in the open where others can see them.
+
+## Running the tooling safely
+
+The guard and the monitors read files and make outbound requests to official Apple, Google, and EU sources. Review any script before running it against a private codebase, as you would with any third-party tooling.
+
+Reports produced in `--simulate` mode contain illustrative sample data, not live announcements. Never treat simulate output as a real requirement.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+title: App Store Compliance Playbook
+message: If you use this playbook in your work, please cite it.
+type: software
+authors:
+  - alias: mjmirza
+    name: Mirza Iqbal
+repository-code: https://github.com/mjmirza/app-store-compliance
+url: https://github.com/mjmirza/app-store-compliance
+abstract: >-
+  An enterprise reference and automated guard that maps Apple App Store and
+  Google Play rejection patterns to the exact guideline and the concrete fix,
+  with machine-readable rejection data, a pre-submission guard, and continuous
+  monitors for Apple, Android, privacy, security, AI policy, accessibility, and
+  global regulatory deadlines.
+keywords:
+  - app store review
+  - google play policy
+  - mobile compliance
+  - app store rejection
+  - privacy manifest
+  - regulatory compliance
+license: MIT


### PR DESCRIPTION
GitHub's community standards checklist flagged a missing security policy and pull request template. This adds those plus the rest of the scaffold that was absent.

Added.

- `.github/SECURITY.md`, private reporting for command injection, path traversal, or exfiltration in the scripts, and public issues for wrong guideline numbers and dead citations, since accuracy reports are the most useful thing this project gets
- `.github/PULL_REQUEST_TEMPLATE.md`, asks for the primary sources actually opened and the real output of `validate.py` and `verify-citations.py`, not a ticked box, and declares that no simulate-mode sample data is committed as a real announcement
- `.github/CODE_OF_CONDUCT.md`, Contributor Covenant 2.1
- `.github/CODEOWNERS`, `.github/dependabot.yml` for github-actions, `.github/FUNDING.yml`
- `.github/ISSUE_TEMPLATE/citation-problem.md` and `tooling-bug.md`, alongside the existing pattern-contribution template
- `CITATION.cff`

Verification.

- All four YAML files parse under `yaml.safe_load`
- Both new issue templates have valid frontmatter with name and about
- `CITATION.cff` parses and carries cff-version, title, and authors

Suggested labels

- documentation
