### PR TITLE
Add cross-platform framework compliance coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,13 @@ Before certifying a release as clear to submit/ship, verify every item below. Ma
   * Rules Reference: `references/rules/export.md`
   * Platform Mechanics: `docs/PLATFORM-MECHANICS-2026.md`
 
+### 15. Cross-Platform Framework Coverage
+* **Verify.** If the project is Flutter (`pubspec.yaml`), React Native/Expo (`package.json` deps), or Ionic/Capacitor/Cordova (`capacitor.config.*`, `config.xml`, or matching deps), confirm the framework-specific findings are addressed. Watch for privacy manifest aggregation gaps for plugin-wrapped native SDKs, undisclosed OTA JS-bundle updaters, the Guideline 4.2 thin-WebView-wrapper rejection, and deprecated UIWebView linkage.
+* **Playbook Mapping**
+  - Doc. `docs/CROSS-PLATFORM-FRAMEWORKS.md`
+  - Guard. `agent-os/hooks/app-store-compliance-guard.sh` (Flutter/React Native/Ionic detection and checks)
+  - Patterns. `data/rejection-patterns.json` -> `FLUTTER-PRIVACY-MANIFEST-MISSING`, `RN-OTA-UNDECLARED`, `RN-PRIVACY-MANIFEST-MISSING`, `IONIC-4.2-THIN-WRAPPER`, `IONIC-UIWEBVIEW-DEPRECATED`, `IONIC-PRIVACY-MANIFEST-MISSING`
+
 ## Release-Time Action Flow
 
 For any software release, in this order:

--- a/agent-os/hooks/app-store-compliance-guard-test.sh
+++ b/agent-os/hooks/app-store-compliance-guard-test.sh
@@ -147,6 +147,17 @@ mk_unrelated_config_xml() {
   echo "$d"
 }
 
+# The real-world Codex-found scenario: a full cross-platform Flutter repo with BOTH ios/ and
+# android/ folders committed (the normal case), building only for Android.
+mk_flutter_both_platforms() {
+  local d; d="$(mktemp -d)"; mkdir -p "$d/ios/Runner" "$d/android/app/src/main" "$d/lib"
+  printf 'name: t\ndependencies:\n  permission_handler: ^11.0.0\n' > "$d/pubspec.yaml"
+  printf "import 'package:permission_handler/permission_handler.dart';\nvoid main(){Permission.camera.request();}\n" > "$d/lib/main.dart"
+  printf '<plist><dict></dict></plist>' > "$d/ios/Runner/Info.plist"
+  printf '<manifest xmlns:android="http://schemas.android.com/apk/res/android"></manifest>' > "$d/android/app/src/main/AndroidManifest.xml"
+  echo "$d"
+}
+
 # 1 positive. iOS with violations blocks
 D="$(mk_ios_bad)"; OUT="$(bash "$GUARD" "$D" 2>&1)"; RC=$?
 echo "$OUT" | grep -q 'CRITICAL' && [ "$RC" -eq 2 ] && ok "iOS violations block (exit 2, has CRITICAL)" || bad "iOS violations block"
@@ -325,6 +336,17 @@ if echo "$OUT" | grep -q 'Ionic/Capacitor/Cordova=0'; then
   ok "Unrelated config.xml (no widget marker) stays silent on Ionic detection"
 else
   bad "Unrelated config.xml (no widget marker) stays silent on Ionic detection"
+fi
+rm -rf "$D"
+
+# 26 Command overrides file-tree presence for a both-platforms repo (docs/CROSS-PLATFORM-FRAMEWORKS.md)
+D="$(mk_flutter_both_platforms)"
+OUT_APK="$(printf '{"tool_input":{"command":"flutter build apk --release"}}' | CLAUDE_PROJECT_DIR="$D" bash "$GUARD" 2>&1)"
+OUT_IPA="$(printf '{"tool_input":{"command":"flutter build ipa --release"}}' | CLAUDE_PROJECT_DIR="$D" bash "$GUARD" 2>&1)"
+if ! echo "$OUT_APK" | grep -q 'FLUTTER-PRIVACY-MANIFEST-MISSING' && echo "$OUT_IPA" | grep -q 'FLUTTER-PRIVACY-MANIFEST-MISSING'; then
+  ok "Command-aware gate: apk build silent, ipa build fires, on the SAME both-platforms repo"
+else
+  bad "Command-aware gate: apk build silent, ipa build fires, on the SAME both-platforms repo"
 fi
 rm -rf "$D"
 

--- a/agent-os/hooks/app-store-compliance-guard-test.sh
+++ b/agent-os/hooks/app-store-compliance-guard-test.sh
@@ -120,6 +120,33 @@ mk_ionic_native_shell() {
   echo "$d"
 }
 
+# Flutter, Android-only (no ios/ folder at all). The iOS-only privacy-manifest check must
+# NOT fire, since flutter build appbundle/apk never touches Info.plist or PrivacyInfo.xcprivacy.
+mk_flutter_android_only() {
+  local d; d="$(mktemp -d)"; mkdir -p "$d/android/app/src/main" "$d/lib"
+  printf 'name: t\ndependencies:\n  permission_handler: ^11.0.0\n' > "$d/pubspec.yaml"
+  printf "import 'package:permission_handler/permission_handler.dart';\nvoid main(){Permission.camera.request();}\n" > "$d/lib/main.dart"
+  printf '<manifest xmlns:android="http://schemas.android.com/apk/res/android"></manifest>' > "$d/android/app/src/main/AndroidManifest.xml"
+  echo "$d"
+}
+
+# Monorepo layout: root package.json is tooling-only, the real RN app lives at apps/mobile/.
+mk_rn_monorepo() {
+  local d; d="$(mktemp -d)"; mkdir -p "$d/apps/mobile/ios/App"
+  printf '{"name":"tooling-root","private":true}' > "$d/package.json"
+  printf '{"dependencies":{"react-native":"0.74.0"}}' > "$d/apps/mobile/package.json"
+  printf '<plist><dict></dict></plist>' > "$d/apps/mobile/ios/App/Info.plist"
+  echo "$d"
+}
+
+# A config.xml that is NOT Cordova (no <widget>/xmlns:cdv marker). Must not flip IS_IONIC.
+mk_unrelated_config_xml() {
+  local d; d="$(mktemp -d)"; mkdir -p "$d/ios/App"
+  printf '<configuration><appSettings></appSettings></configuration>' > "$d/config.xml"
+  printf '<plist><dict></dict></plist>' > "$d/ios/App/Info.plist"
+  echo "$d"
+}
+
 # 1 positive. iOS with violations blocks
 D="$(mk_ios_bad)"; OUT="$(bash "$GUARD" "$D" 2>&1)"; RC=$?
 echo "$OUT" | grep -q 'CRITICAL' && [ "$RC" -eq 2 ] && ok "iOS violations block (exit 2, has CRITICAL)" || bad "iOS violations block"
@@ -247,12 +274,13 @@ else
 fi
 rm -rf "$D"
 
-# 20 Ionic thin wrapper (WebView, <2 native plugins) blocks on 4.2
-D="$(mk_ionic_thin_wrapper)"; OUT="$(bash "$GUARD" "$D" 2>&1)"; RC=$?
-if echo "$OUT" | grep -q 'Ionic/Capacitor/Cordova=1' && echo "$OUT" | grep -q 'IONIC-4.2-THIN-WRAPPER' && [ "$RC" -eq 2 ]; then
-  ok "Ionic thin wrapper blocks on 4.2 minimum functionality"
+# 20 Ionic thin wrapper (WebView, <2 native plugins) fires as HIGH (advisory heuristic, not a
+# hard blocker per council review, since plugin-count is a proxy, not the real Apple 4.2 test)
+D="$(mk_ionic_thin_wrapper)"; OUT="$(bash "$GUARD" "$D" 2>&1)"
+if echo "$OUT" | grep -q 'Ionic/Capacitor/Cordova=1' && echo "$OUT" | grep -q 'IONIC-4.2-THIN-WRAPPER'; then
+  ok "Ionic thin wrapper fires as high-severity advisory on 4.2 minimum functionality"
 else
-  bad "Ionic thin wrapper blocks on 4.2 minimum functionality (rc=$RC)"
+  bad "Ionic thin wrapper fires as high-severity advisory on 4.2 minimum functionality"
 fi
 rm -rf "$D"
 
@@ -272,6 +300,33 @@ for cmd in "flutter build ipa --release" "npx cap sync ios" "ionic capacitor bui
   echo "$OUT" | grep -q 'App Store Compliance Guard' || MISS_CMD="$MISS_CMD [$cmd]"
 done
 [ -z "$MISS_CMD" ] && ok "Submission regex catches flutter/cap/ionic/eas/cordova build commands" || bad "Submission regex missed:$MISS_CMD"
+
+# 23 Council-found bug fix: Flutter Android-only build must NOT trigger the iOS-only privacy check
+D="$(mk_flutter_android_only)"; OUT="$(bash "$GUARD" "$D" 2>&1)"; RC=$?
+if ! echo "$OUT" | grep -q 'FLUTTER-PRIVACY-MANIFEST-MISSING'; then
+  ok "Flutter Android-only build stays silent on iOS-only privacy check"
+else
+  bad "Flutter Android-only build wrongly fired the iOS-only privacy check (rc=$RC)"
+fi
+rm -rf "$D"
+
+# 24 Council-found bug fix: monorepo detection scans every package.json, not just the first
+D="$(mk_rn_monorepo)"; OUT="$(bash "$GUARD" "$D" 2>&1)"
+if echo "$OUT" | grep -q 'ReactNative/Expo=1'; then
+  ok "Monorepo React Native detected via nested apps/mobile/package.json"
+else
+  bad "Monorepo React Native detected via nested apps/mobile/package.json"
+fi
+rm -rf "$D"
+
+# 25 Council-found bug fix: an unrelated config.xml (no Cordova widget marker) must not flip IS_IONIC
+D="$(mk_unrelated_config_xml)"; OUT="$(bash "$GUARD" "$D" 2>&1)"
+if echo "$OUT" | grep -q 'Ionic/Capacitor/Cordova=0'; then
+  ok "Unrelated config.xml (no widget marker) stays silent on Ionic detection"
+else
+  bad "Unrelated config.xml (no widget marker) stays silent on Ionic detection"
+fi
+rm -rf "$D"
 
 echo ""
 echo "app-store-compliance-guard-test: $PASS passed, $FAIL failed"

--- a/agent-os/hooks/app-store-compliance-guard-test.sh
+++ b/agent-os/hooks/app-store-compliance-guard-test.sh
@@ -82,6 +82,44 @@ mk_web_clean() {
   echo "$d"
 }
 
+# Flutter with a required-reason plugin and no PrivacyInfo.xcprivacy anywhere.
+mk_flutter_bad() {
+  local d; d="$(mktemp -d)"; mkdir -p "$d/ios/Runner" "$d/lib"
+  printf 'name: t\ndependencies:\n  permission_handler: ^11.0.0\n' > "$d/pubspec.yaml"
+  printf "import 'package:permission_handler/permission_handler.dart';\nvoid main(){Permission.camera.request();}\n" > "$d/lib/main.dart"
+  printf '<plist><dict></dict></plist>' > "$d/ios/Runner/Info.plist"
+  echo "$d"
+}
+
+# React Native + an undisclosed OTA updater (CodePush).
+mk_rn_bad() {
+  local d; d="$(mktemp -d)"; mkdir -p "$d/ios/App"
+  printf '{"dependencies":{"react-native":"0.74.0","react-native-code-push":"^8.0.0"}}' > "$d/package.json"
+  printf 'import codePush from "react-native-code-push";\ncodePush.sync();\n' > "$d/App.tsx"
+  printf '<plist><dict></dict></plist>' > "$d/ios/App/Info.plist"
+  echo "$d"
+}
+
+# Ionic/Capacitor thin wrapper. WebView present, fewer than 2 native-feel plugins.
+mk_ionic_thin_wrapper() {
+  local d; d="$(mktemp -d)"; mkdir -p "$d/ios/App" "$d/src"
+  printf '{"dependencies":{"@capacitor/core":"^6.0.0","@ionic/angular":"^8.0.0"}}' > "$d/package.json"
+  printf 'export default {};' > "$d/capacitor.config.ts"
+  printf "import { Capacitor } from '@capacitor/core';\nconst wv = new WKWebView();\n" > "$d/src/app.ts"
+  printf '<plist><dict></dict></plist>' > "$d/ios/App/Info.plist"
+  echo "$d"
+}
+
+# Same shape but with 3 distinct native-feel plugins. Thin-wrapper must NOT fire.
+mk_ionic_native_shell() {
+  local d; d="$(mktemp -d)"; mkdir -p "$d/ios/App" "$d/src"
+  printf '{"dependencies":{"@capacitor/core":"^6.0.0","@ionic/angular":"^8.0.0"}}' > "$d/package.json"
+  printf 'export default {};' > "$d/capacitor.config.ts"
+  printf "import { Capacitor } from '@capacitor/core';\nimport '@capacitor/status-bar';\nimport '@capacitor/splash-screen';\nimport '@capacitor/push-notifications';\nconst wv = new WKWebView();\n" > "$d/src/app.ts"
+  printf '<plist><dict></dict></plist>' > "$d/ios/App/Info.plist"
+  echo "$d"
+}
+
 # 1 positive. iOS with violations blocks
 D="$(mk_ios_bad)"; OUT="$(bash "$GUARD" "$D" 2>&1)"; RC=$?
 echo "$OUT" | grep -q 'CRITICAL' && [ "$RC" -eq 2 ] && ok "iOS violations block (exit 2, has CRITICAL)" || bad "iOS violations block"
@@ -190,6 +228,50 @@ else
   bad "Subscription self-service cancel stays silent"
 fi
 rm -rf "$D"
+
+# 18 Flutter framework detected + privacy manifest gap blocks
+D="$(mk_flutter_bad)"; OUT="$(bash "$GUARD" "$D" 2>&1)"; RC=$?
+if echo "$OUT" | grep -q 'Flutter=1' && echo "$OUT" | grep -q 'FLUTTER-PRIVACY-MANIFEST-MISSING' && [ "$RC" -eq 2 ]; then
+  ok "Flutter detected, missing privacy manifest blocks"
+else
+  bad "Flutter detected, missing privacy manifest blocks (rc=$RC)"
+fi
+rm -rf "$D"
+
+# 19 React Native + undisclosed CodePush OTA fires (non-critical, does not block alone)
+D="$(mk_rn_bad)"; OUT="$(bash "$GUARD" "$D" 2>&1)"
+if echo "$OUT" | grep -q 'ReactNative/Expo=1' && echo "$OUT" | grep -q 'RN-OTA-UNDECLARED'; then
+  ok "React Native detected, undisclosed CodePush OTA fires"
+else
+  bad "React Native detected, undisclosed CodePush OTA fires"
+fi
+rm -rf "$D"
+
+# 20 Ionic thin wrapper (WebView, <2 native plugins) blocks on 4.2
+D="$(mk_ionic_thin_wrapper)"; OUT="$(bash "$GUARD" "$D" 2>&1)"; RC=$?
+if echo "$OUT" | grep -q 'Ionic/Capacitor/Cordova=1' && echo "$OUT" | grep -q 'IONIC-4.2-THIN-WRAPPER' && [ "$RC" -eq 2 ]; then
+  ok "Ionic thin wrapper blocks on 4.2 minimum functionality"
+else
+  bad "Ionic thin wrapper blocks on 4.2 minimum functionality (rc=$RC)"
+fi
+rm -rf "$D"
+
+# 21 Ionic with 3 distinct native-feel plugins does NOT trip the thin-wrapper false positive
+D="$(mk_ionic_native_shell)"; OUT="$(bash "$GUARD" "$D" 2>&1)"
+if ! echo "$OUT" | grep -q 'IONIC-4.2-THIN-WRAPPER'; then
+  ok "Ionic with real native plugin shell stays silent on thin-wrapper"
+else
+  bad "Ionic with real native plugin shell stays silent on thin-wrapper (false positive)"
+fi
+rm -rf "$D"
+
+# 22 Submission-command regex now catches Flutter, Capacitor, Ionic, EAS, Cordova build commands
+MISS_CMD=""
+for cmd in "flutter build ipa --release" "npx cap sync ios" "ionic capacitor build ios --prod" "eas build --platform ios" "cordova build ios --release"; do
+  OUT="$(printf '{"tool_input":{"command":"%s"}}' "$cmd" | bash "$GUARD" 2>&1)"
+  echo "$OUT" | grep -q 'App Store Compliance Guard' || MISS_CMD="$MISS_CMD [$cmd]"
+done
+[ -z "$MISS_CMD" ] && ok "Submission regex catches flutter/cap/ionic/eas/cordova build commands" || bad "Submission regex missed:$MISS_CMD"
 
 echo ""
 echo "app-store-compliance-guard-test: $PASS passed, $FAIL failed"

--- a/agent-os/hooks/app-store-compliance-guard.sh
+++ b/agent-os/hooks/app-store-compliance-guard.sh
@@ -27,7 +27,7 @@ fi
 if [ -n "$STDIN_JSON" ]; then
   CMD="$(printf '%s' "$STDIN_JSON" | grep -oE '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*:[[:space:]]*"//; s/"$//')"
   # Only act on submission style commands. Otherwise stay silent.
-  if ! printf '%s' "$CMD" | grep -qiE 'fastlane[[:space:]]+(deliver|pilot|supply|submit)|eas[[:space:]]+(submit|build)|xcrun[[:space:]]+(altool|notarytool)|transporter|gradlew?[^&|;]*(bundleRelease|assembleRelease)|bundletool|xcodebuild[^&|;]*archive|flutter[[:space:]]+build[[:space:]]+(ipa|appbundle|apk)|(npx[[:space:]]+)?cap[[:space:]]+(sync|build|run)|ionic[[:space:]]+capacitor[[:space:]]+(build|run)|cordova[[:space:]]+build([[:space:]]+--release)?'; then
+  if ! printf '%s' "$CMD" | grep -qiE 'fastlane[[:space:]]+(deliver|pilot|supply|submit)|eas[[:space:]]+(submit|build)|xcrun[[:space:]]+(altool|notarytool)|transporter|gradlew?[^&|;]*(bundleRelease|assembleRelease)|bundletool|xcodebuild[^&|;]*archive|flutter[[:space:]]+build[[:space:]]+(ipa|appbundle|apk|ios)|(npx[[:space:]]+)?(expo[[:space:]]+(prebuild|run:ios|run:android)|cap[[:space:]]+(sync|build|run|copy|open)|react-native[[:space:]]+run-(ios|android))|ionic[[:space:]]+capacitor[[:space:]]+(build|run)|cordova[[:space:]]+build([[:space:]]+--release)?'; then
     exit 0
   fi
   DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
@@ -103,13 +103,19 @@ find "$DIR" -maxdepth 4 \( -name 'package.json' -o -name 'index.html' -o -name '
 # ----- cross-platform framework detection -----
 # IS_IOS/IS_AND above still fire on the built artifact. This adds framework-specific checks.
 IS_FLUTTER=0; IS_RN=0; IS_IONIC=0
-find "$DIR" -maxdepth 3 -name 'pubspec.yaml' 2>/dev/null | grep -q . && IS_FLUTTER=1
-PKGJSON="$(find "$DIR" -maxdepth 3 -name 'package.json' 2>/dev/null | grep -vE '/(node_modules|ios/Pods)/' | head -1)"
-if [ -n "$PKGJSON" ]; then
-  grep -qE '"react-native"|"expo"' "$PKGJSON" 2>/dev/null && IS_RN=1
-  grep -qE '"@capacitor/core"|"@capacitor/ios"|"@capacitor/android"|"@ionic/(angular|react|vue)"|"cordova-android"|"cordova-ios"' "$PKGJSON" 2>/dev/null && IS_IONIC=1
-fi
-find "$DIR" -maxdepth 3 \( -name 'capacitor.config.*' -o -name 'config.xml' \) 2>/dev/null | grep -q . && IS_IONIC=1
+find "$DIR" -maxdepth 4 -name 'pubspec.yaml' 2>/dev/null | grep -q . && IS_FLUTTER=1
+# Scan EVERY package.json within depth (not just the first), so a monorepo root's tooling
+# package.json never shadows a real apps/mobile/package.json deeper in the tree.
+while IFS= read -r pkg; do
+  grep -qE '"react-native"|"expo"' "$pkg" 2>/dev/null && IS_RN=1
+  grep -qE '"@capacitor/core"|"@capacitor/ios"|"@capacitor/android"|"@ionic/(angular|react|vue)"|"cordova-android"|"cordova-ios"' "$pkg" 2>/dev/null && IS_IONIC=1
+done < <(find "$DIR" -maxdepth 4 -name 'package.json' 2>/dev/null | grep -vE '/(node_modules|ios/Pods)/')
+find "$DIR" -maxdepth 4 -name 'capacitor.config.*' 2>/dev/null | grep -q . && IS_IONIC=1
+# config.xml alone is ambiguous (Maven/NuGet/tooling also use that filename), so require the
+# Cordova widget marker before it counts as a signal.
+while IFS= read -r cfg; do
+  grep -qE '<widget|xmlns:cdv' "$cfg" 2>/dev/null && IS_IONIC=1
+done < <(find "$DIR" -maxdepth 4 -name 'config.xml' 2>/dev/null)
 
 echo "== App Store Compliance Guard =="
 echo "Project. $DIR"
@@ -154,19 +160,21 @@ if grep_has 'loot ?box|gacha|mystery box|random reward'; then
 fi
 
 # ===== Flutter checks =====
+# iOS-only Apple requirement, gated on IS_IOS so an Android-only build is never blocked for it.
 if [ "$IS_FLUTTER" -eq 1 ]; then
-  if grep_has 'permission_handler|image_picker|geolocator|device_info_plus|package_info_plus|shared_preferences|sqflite|firebase_'; then
+  if [ "$IS_IOS" -eq 1 ] && grep_has 'permission_handler|image_picker|geolocator|device_info_plus|package_info_plus|shared_preferences|sqflite|firebase_'; then
     if ! find "$DIR" -name 'PrivacyInfo.xcprivacy' 2>/dev/null | grep -q .; then
-      finding critical "FLUTTER-PRIVACY-MANIFEST-MISSING" "Flutter plugins that touch required-reason APIs but no PrivacyInfo.xcprivacy anywhere in the project" "Add an app-level PrivacyInfo.xcprivacy AND confirm each Flutter plugin ships its own (permission_handler, image_picker, and most first-party plugins added theirs from Flutter 3.19+). A missing plugin-level manifest is invisible to Apple's aggregator unless the app manifest also declares that plugin's reason codes."
+      finding critical "FLUTTER-PRIVACY-MANIFEST-MISSING" "Flutter plugins that touch required-reason APIs but no PrivacyInfo.xcprivacy anywhere in the project" "Add an app-level PrivacyInfo.xcprivacy AND confirm each Flutter plugin ships its own (permission_handler, image_picker, and most first-party plugins added theirs from Flutter 3.19+). A missing plugin-level manifest is invisible to Apple's aggregator unless the app manifest also declares that plugin's reason codes. This check only runs against an iOS target."
     fi
   fi
   if [ "$IS_IOS" -eq 0 ]; then
-    finding medium "FLUTTER-NO-IOS-RUNNER-FOUND" "No ios/Runner target detected next to pubspec.yaml" "Run flutter create . or confirm the ios/ platform folder exists before an iOS submission; this guard skipped every iOS-specific check because no Info.plist was found."
+    finding medium "FLUTTER-NO-IOS-RUNNER-FOUND" "No ios/Runner target detected next to pubspec.yaml" "If this is an iOS submission, run flutter create . or confirm the ios/ platform folder exists. A pure Android build never needs one."
   fi
 fi
 
 # ===== React Native / Expo checks =====
-if [ "$IS_RN" -eq 1 ]; then
+# Both findings are Apple-specific (3.3.2/2.5.2 disclosure, iOS privacy manifest), IS_IOS-gated.
+if [ "$IS_RN" -eq 1 ] && [ "$IS_IOS" -eq 1 ]; then
   if grep_has 'react-native-code-push|CodePush\.|expo-updates|Updates\.checkForUpdate|react-native-ota-hot-update|@stallion-js|Stallion\.'; then
     if ! grep_has 'reviewNotes|App Review|bug.fix.only|bugfix.only'; then
       finding high "RN-OTA-UNDECLARED" "An over-the-air JS bundle updater (CodePush, Expo Updates, or similar) is present" "Disclose the OTA mechanism by name in App Review notes, restrict its use to bug fixes that do not change the app's purpose, UI, or add features beyond what was reviewed (Apple 3.3.2, 2.5.2)."
@@ -180,11 +188,12 @@ if [ "$IS_RN" -eq 1 ]; then
 fi
 
 # ===== Ionic / Capacitor / Cordova checks =====
-if [ "$IS_IONIC" -eq 1 ]; then
+# All three are Apple-side (4.2, UIWebView, iOS privacy manifest), IS_IOS-gated as above.
+if [ "$IS_IONIC" -eq 1 ] && [ "$IS_IOS" -eq 1 ]; then
   WRAPPER_COUNT="$( [ -s "$FILELIST" ] && tr '\n' '\0' < "$FILELIST" | xargs -0 grep -EIl -e 'WKWebView|loadRequest|Capacitor|Cordova' 2>/dev/null | wc -l | tr -d '[:space:]' || echo 0)"
   NATIVE_PLUGIN_COUNT="$( [ -s "$FILELIST" ] && tr '\n' '\0' < "$FILELIST" | xargs -0 grep -EIho -e '@capacitor/(push-notifications|status-bar|splash-screen|haptics|share|camera|local-notifications)|cordova-plugin-(statusbar|splashscreen|push)' 2>/dev/null | sort -u | wc -l | tr -d '[:space:]' || echo 0)"
   if [ "${WRAPPER_COUNT:-0}" -gt 0 ] && [ "${NATIVE_PLUGIN_COUNT:-0}" -lt 2 ]; then
-    finding critical "IONIC-4.2-THIN-WRAPPER" "WebView/Capacitor/Cordova present with fewer than 2 native-feel plugins (status bar, splash screen, push, haptics)" "Apple 4.2 Minimum Functionality is the single most common Ionic rejection: a full-screen webview with no native chrome reads as a website, not an app. Add native Capacitor/Cordova plugins for status bar, splash transition, push notifications, and haptics, or ship as an installable PWA to skip App Review entirely."
+    finding high "IONIC-4.2-THIN-WRAPPER" "WebView/Capacitor/Cordova present with fewer than 2 recognized native-feel plugins (status bar, splash screen, push, haptics)" "This is a heuristic proxy, not the actual Apple 4.2 test (features/content/UI beyond a repackaged website); review manually before treating it as a hard blocker. Add native Capacitor/Cordova plugins for status bar, splash transition, push, and haptics, or ship as an installable PWA to skip App Review entirely."
   fi
   if grep_has 'UIWebView'; then
     finding critical "IONIC-UIWEBVIEW-DEPRECATED" "Deprecated UIWebView symbol referenced (directly or via a stale plugin)" "Apple auto-rejects (ITMS-90809) any binary statically linking UIWebView. Update every Capacitor/Cordova plugin to a version using WKWebView; a stale plugin can pull this in even when app code never references it."

--- a/agent-os/hooks/app-store-compliance-guard.sh
+++ b/agent-os/hooks/app-store-compliance-guard.sh
@@ -18,6 +18,7 @@ trap cleanup EXIT
 # ----- resolve mode and project dir -----
 DIR=""
 STDIN_JSON=""
+CMD=""
 if [ "$#" -ge 1 ] && [ -d "$1" ]; then
   DIR="$1"                                   # standalone with explicit path
 elif [ ! -t 0 ]; then
@@ -31,6 +32,15 @@ if [ -n "$STDIN_JSON" ]; then
     exit 0
   fi
   DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+fi
+
+# See docs/CROSS-PLATFORM-FRAMEWORKS.md: an Android-only command beats a committed ios/
+# folder for the Apple-only checks below (standalone mode has no CMD, unaffected).
+CMD_TARGET_ANDROID_ONLY=0
+if [ -n "$CMD" ] \
+  && printf '%s' "$CMD" | grep -qiE 'build[[:space:]]+(apk|appbundle)\b|assembleRelease|bundleRelease|run-android|run:android|--platform[[:space:]]+android\b|capacitor[[:space:]]+android\b' \
+  && ! printf '%s' "$CMD" | grep -qiE '\bios\b|\bipa\b|xcodebuild|altool|notarytool'; then
+  CMD_TARGET_ANDROID_ONLY=1
 fi
 
 [ -z "$DIR" ] && DIR="$PWD"
@@ -117,10 +127,16 @@ while IFS= read -r cfg; do
   grep -qE '<widget|xmlns:cdv' "$cfg" 2>/dev/null && IS_IONIC=1
 done < <(find "$DIR" -maxdepth 4 -name 'config.xml' 2>/dev/null)
 
+# The actual gate the framework checks below use: a committed ios/ folder AND the
+# invoking command (when known) does not explicitly target Android-only.
+IOS_TARGET_ACTIVE=0
+[ "$IS_IOS" -eq 1 ] && [ "$CMD_TARGET_ANDROID_ONLY" -eq 0 ] && IOS_TARGET_ACTIVE=1
+
 echo "== App Store Compliance Guard =="
 echo "Project. $DIR"
 echo "Platforms. iOS=$IS_IOS Android=$IS_AND Web=$IS_WEB"
 echo "Frameworks. Flutter=$IS_FLUTTER ReactNative/Expo=$IS_RN Ionic/Capacitor/Cordova=$IS_IONIC"
+[ "$CMD_TARGET_ANDROID_ONLY" -eq 1 ] && echo "Command targets Android only. Apple-only framework checks suppressed for this run."
 echo ""
 
 # ----- run regulatory deadlines check -----
@@ -162,7 +178,7 @@ fi
 # ===== Flutter checks =====
 # iOS-only Apple requirement, gated on IS_IOS so an Android-only build is never blocked for it.
 if [ "$IS_FLUTTER" -eq 1 ]; then
-  if [ "$IS_IOS" -eq 1 ] && grep_has 'permission_handler|image_picker|geolocator|device_info_plus|package_info_plus|shared_preferences|sqflite|firebase_'; then
+  if [ "$IOS_TARGET_ACTIVE" -eq 1 ] && grep_has 'permission_handler|image_picker|geolocator|device_info_plus|package_info_plus|shared_preferences|sqflite|firebase_'; then
     if ! find "$DIR" -name 'PrivacyInfo.xcprivacy' 2>/dev/null | grep -q .; then
       finding critical "FLUTTER-PRIVACY-MANIFEST-MISSING" "Flutter plugins that touch required-reason APIs but no PrivacyInfo.xcprivacy anywhere in the project" "Add an app-level PrivacyInfo.xcprivacy AND confirm each Flutter plugin ships its own (permission_handler, image_picker, and most first-party plugins added theirs from Flutter 3.19+). A missing plugin-level manifest is invisible to Apple's aggregator unless the app manifest also declares that plugin's reason codes. This check only runs against an iOS target."
     fi
@@ -174,7 +190,7 @@ fi
 
 # ===== React Native / Expo checks =====
 # Both findings are Apple-specific (3.3.2/2.5.2 disclosure, iOS privacy manifest), IS_IOS-gated.
-if [ "$IS_RN" -eq 1 ] && [ "$IS_IOS" -eq 1 ]; then
+if [ "$IS_RN" -eq 1 ] && [ "$IOS_TARGET_ACTIVE" -eq 1 ]; then
   if grep_has 'react-native-code-push|CodePush\.|expo-updates|Updates\.checkForUpdate|react-native-ota-hot-update|@stallion-js|Stallion\.'; then
     if ! grep_has 'reviewNotes|App Review|bug.fix.only|bugfix.only'; then
       finding high "RN-OTA-UNDECLARED" "An over-the-air JS bundle updater (CodePush, Expo Updates, or similar) is present" "Disclose the OTA mechanism by name in App Review notes, restrict its use to bug fixes that do not change the app's purpose, UI, or add features beyond what was reviewed (Apple 3.3.2, 2.5.2)."
@@ -189,7 +205,7 @@ fi
 
 # ===== Ionic / Capacitor / Cordova checks =====
 # All three are Apple-side (4.2, UIWebView, iOS privacy manifest), IS_IOS-gated as above.
-if [ "$IS_IONIC" -eq 1 ] && [ "$IS_IOS" -eq 1 ]; then
+if [ "$IS_IONIC" -eq 1 ] && [ "$IOS_TARGET_ACTIVE" -eq 1 ]; then
   WRAPPER_COUNT="$( [ -s "$FILELIST" ] && tr '\n' '\0' < "$FILELIST" | xargs -0 grep -EIl -e 'WKWebView|loadRequest|Capacitor|Cordova' 2>/dev/null | wc -l | tr -d '[:space:]' || echo 0)"
   NATIVE_PLUGIN_COUNT="$( [ -s "$FILELIST" ] && tr '\n' '\0' < "$FILELIST" | xargs -0 grep -EIho -e '@capacitor/(push-notifications|status-bar|splash-screen|haptics|share|camera|local-notifications)|cordova-plugin-(statusbar|splashscreen|push)' 2>/dev/null | sort -u | wc -l | tr -d '[:space:]' || echo 0)"
   if [ "${WRAPPER_COUNT:-0}" -gt 0 ] && [ "${NATIVE_PLUGIN_COUNT:-0}" -lt 2 ]; then

--- a/agent-os/hooks/app-store-compliance-guard.sh
+++ b/agent-os/hooks/app-store-compliance-guard.sh
@@ -1,17 +1,6 @@
 #!/usr/bin/env bash
-# App Store Compliance Guard
-# Scans a mobile app project for the rejection patterns that cause most App Store
-# and Google Play rejections, before a build is uploaded.
-#
-# Two modes.
-#   1. Standalone.  app-store-compliance-guard.sh /path/to/project
-#   2. agent-os PreToolUse hook on Bash. Fires only when the command looks like an
-#      app submission (fastlane, eas submit, xcrun altool, gradle bundleRelease,
-#      bundletool, xcodebuild archive). Blocks on a critical finding.
-#
-# Exit codes. 0 clean or advisory, 2 critical finding (blocks the submission).
-# Override the block with APP_STORE_GUARD_OK=1.
-#
+# App Store Compliance Guard. Native and cross-platform (Flutter, RN/Expo, Ionic/Capacitor).
+# Standalone or PreToolUse Bash hook on a submit command. See docs/CROSS-PLATFORM-FRAMEWORKS.md.
 # @event: PreToolUse
 # @matcher: Bash
 set -uo pipefail
@@ -38,7 +27,7 @@ fi
 if [ -n "$STDIN_JSON" ]; then
   CMD="$(printf '%s' "$STDIN_JSON" | grep -oE '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*:[[:space:]]*"//; s/"$//')"
   # Only act on submission style commands. Otherwise stay silent.
-  if ! printf '%s' "$CMD" | grep -qiE 'fastlane[[:space:]]+(deliver|pilot|supply|submit)|eas[[:space:]]+submit|xcrun[[:space:]]+(altool|notarytool)|transporter|gradlew?[^&|;]*(bundleRelease|assembleRelease)|bundletool|xcodebuild[^&|;]*archive'; then
+  if ! printf '%s' "$CMD" | grep -qiE 'fastlane[[:space:]]+(deliver|pilot|supply|submit)|eas[[:space:]]+(submit|build)|xcrun[[:space:]]+(altool|notarytool)|transporter|gradlew?[^&|;]*(bundleRelease|assembleRelease)|bundletool|xcodebuild[^&|;]*archive|flutter[[:space:]]+build[[:space:]]+(ipa|appbundle|apk)|(npx[[:space:]]+)?cap[[:space:]]+(sync|build|run)|ionic[[:space:]]+capacitor[[:space:]]+(build|run)|cordova[[:space:]]+build([[:space:]]+--release)?'; then
     exit 0
   fi
   DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
@@ -52,7 +41,8 @@ FILELIST="$(mktemp 2>/dev/null || echo /tmp/ascg.$$)"
 find "$DIR" -type f \( \
   -name '*.swift' -o -name '*.m' -o -name '*.h' -o -name '*.kt' -o -name '*.java' \
   -o -name '*.xml' -o -name '*.plist' -o -name '*.gradle' -o -name '*.kts' \
-  -o -name '*.json' -o -name '*.js' -o -name '*.ts' -o -name '*.dart' -o -name '*.xcconfig' \
+  -o -name '*.json' -o -name '*.js' -o -name '*.jsx' -o -name '*.ts' -o -name '*.tsx' \
+  -o -name '*.dart' -o -name '*.xcconfig' -o -name '*.yaml' -o -name '*.yml' \
   -o -name '*.pbxproj' -o -name '*.entitlements' -o -name '*.html' \
   \) 2>/dev/null \
   | grep -vE '/(node_modules|Pods|\.git|build|DerivedData|vendor|\.dart_tool|Carthage|[A-Za-z0-9_]*Tests|androidTest|__tests__)/' \
@@ -110,9 +100,21 @@ find "$DIR" -maxdepth 4 -name 'Info.plist' 2>/dev/null | grep -q . && IS_IOS=1
 find "$DIR" -maxdepth 5 \( -name 'AndroidManifest.xml' -o -name 'build.gradle' -o -name 'build.gradle.kts' \) 2>/dev/null | grep -q . && IS_AND=1
 find "$DIR" -maxdepth 4 \( -name 'package.json' -o -name 'index.html' -o -name 'webpack.config.js' -o -name 'next.config.js' \) 2>/dev/null | grep -q . && IS_WEB=1
 
+# ----- cross-platform framework detection -----
+# IS_IOS/IS_AND above still fire on the built artifact. This adds framework-specific checks.
+IS_FLUTTER=0; IS_RN=0; IS_IONIC=0
+find "$DIR" -maxdepth 3 -name 'pubspec.yaml' 2>/dev/null | grep -q . && IS_FLUTTER=1
+PKGJSON="$(find "$DIR" -maxdepth 3 -name 'package.json' 2>/dev/null | grep -vE '/(node_modules|ios/Pods)/' | head -1)"
+if [ -n "$PKGJSON" ]; then
+  grep -qE '"react-native"|"expo"' "$PKGJSON" 2>/dev/null && IS_RN=1
+  grep -qE '"@capacitor/core"|"@capacitor/ios"|"@capacitor/android"|"@ionic/(angular|react|vue)"|"cordova-android"|"cordova-ios"' "$PKGJSON" 2>/dev/null && IS_IONIC=1
+fi
+find "$DIR" -maxdepth 3 \( -name 'capacitor.config.*' -o -name 'config.xml' \) 2>/dev/null | grep -q . && IS_IONIC=1
+
 echo "== App Store Compliance Guard =="
 echo "Project. $DIR"
 echo "Platforms. iOS=$IS_IOS Android=$IS_AND Web=$IS_WEB"
+echo "Frameworks. Flutter=$IS_FLUTTER ReactNative/Expo=$IS_RN Ionic/Capacitor/Cordova=$IS_IONIC"
 echo ""
 
 # ----- run regulatory deadlines check -----
@@ -149,6 +151,49 @@ if grep_has 'iOS bug|apple bug|broken on iOS'; then
 fi
 if grep_has 'loot ?box|gacha|mystery box|random reward'; then
   finding high "BOTH-LOOTBOX-ODDS" "Random reward mechanic present" "Disclose the odds for every random reward before purchase (Apple 3.1.1, Google gambling)."
+fi
+
+# ===== Flutter checks =====
+if [ "$IS_FLUTTER" -eq 1 ]; then
+  if grep_has 'permission_handler|image_picker|geolocator|device_info_plus|package_info_plus|shared_preferences|sqflite|firebase_'; then
+    if ! find "$DIR" -name 'PrivacyInfo.xcprivacy' 2>/dev/null | grep -q .; then
+      finding critical "FLUTTER-PRIVACY-MANIFEST-MISSING" "Flutter plugins that touch required-reason APIs but no PrivacyInfo.xcprivacy anywhere in the project" "Add an app-level PrivacyInfo.xcprivacy AND confirm each Flutter plugin ships its own (permission_handler, image_picker, and most first-party plugins added theirs from Flutter 3.19+). A missing plugin-level manifest is invisible to Apple's aggregator unless the app manifest also declares that plugin's reason codes."
+    fi
+  fi
+  if [ "$IS_IOS" -eq 0 ]; then
+    finding medium "FLUTTER-NO-IOS-RUNNER-FOUND" "No ios/Runner target detected next to pubspec.yaml" "Run flutter create . or confirm the ios/ platform folder exists before an iOS submission; this guard skipped every iOS-specific check because no Info.plist was found."
+  fi
+fi
+
+# ===== React Native / Expo checks =====
+if [ "$IS_RN" -eq 1 ]; then
+  if grep_has 'react-native-code-push|CodePush\.|expo-updates|Updates\.checkForUpdate|react-native-ota-hot-update|@stallion-js|Stallion\.'; then
+    if ! grep_has 'reviewNotes|App Review|bug.fix.only|bugfix.only'; then
+      finding high "RN-OTA-UNDECLARED" "An over-the-air JS bundle updater (CodePush, Expo Updates, or similar) is present" "Disclose the OTA mechanism by name in App Review notes, restrict its use to bug fixes that do not change the app's purpose, UI, or add features beyond what was reviewed (Apple 3.3.2, 2.5.2)."
+    fi
+  fi
+  if grep_has 'Firebase|@react-native-firebase|expo-file-system|expo-application|AsyncStorage|@react-native-async-storage'; then
+    if ! find "$DIR" -name 'PrivacyInfo.xcprivacy' 2>/dev/null | grep -q .; then
+      finding critical "RN-PRIVACY-MANIFEST-MISSING" "React Native native modules that touch required-reason APIs but no PrivacyInfo.xcprivacy anywhere" "Add an app-level PrivacyInfo.xcprivacy. Native modules bundled transitively via JS deps (analytics, storage, device-info libraries) each need their own manifest aggregated in the final IPA; this is easy to miss because the dependency is JS-side."
+    fi
+  fi
+fi
+
+# ===== Ionic / Capacitor / Cordova checks =====
+if [ "$IS_IONIC" -eq 1 ]; then
+  WRAPPER_COUNT="$( [ -s "$FILELIST" ] && tr '\n' '\0' < "$FILELIST" | xargs -0 grep -EIl -e 'WKWebView|loadRequest|Capacitor|Cordova' 2>/dev/null | wc -l | tr -d '[:space:]' || echo 0)"
+  NATIVE_PLUGIN_COUNT="$( [ -s "$FILELIST" ] && tr '\n' '\0' < "$FILELIST" | xargs -0 grep -EIho -e '@capacitor/(push-notifications|status-bar|splash-screen|haptics|share|camera|local-notifications)|cordova-plugin-(statusbar|splashscreen|push)' 2>/dev/null | sort -u | wc -l | tr -d '[:space:]' || echo 0)"
+  if [ "${WRAPPER_COUNT:-0}" -gt 0 ] && [ "${NATIVE_PLUGIN_COUNT:-0}" -lt 2 ]; then
+    finding critical "IONIC-4.2-THIN-WRAPPER" "WebView/Capacitor/Cordova present with fewer than 2 native-feel plugins (status bar, splash screen, push, haptics)" "Apple 4.2 Minimum Functionality is the single most common Ionic rejection: a full-screen webview with no native chrome reads as a website, not an app. Add native Capacitor/Cordova plugins for status bar, splash transition, push notifications, and haptics, or ship as an installable PWA to skip App Review entirely."
+  fi
+  if grep_has 'UIWebView'; then
+    finding critical "IONIC-UIWEBVIEW-DEPRECATED" "Deprecated UIWebView symbol referenced (directly or via a stale plugin)" "Apple auto-rejects (ITMS-90809) any binary statically linking UIWebView. Update every Capacitor/Cordova plugin to a version using WKWebView; a stale plugin can pull this in even when app code never references it."
+  fi
+  if grep_has '@capacitor/|Capacitor\.'; then
+    if ! find "$DIR" -name 'PrivacyInfo.xcprivacy' 2>/dev/null | grep -q .; then
+      finding high "IONIC-PRIVACY-MANIFEST-MISSING" "Capacitor/Cordova plugins present but no PrivacyInfo.xcprivacy" "Capacitor plugin manifest support is less standardized than Flutter's; verify each plugin wrapping a native SDK (camera, geolocation, ads) ships PrivacyInfo.xcprivacy, and add the app-level one."
+    fi
+  fi
 fi
 
 # ===== iOS checks =====

--- a/data/detection-recipes.json
+++ b/data/detection-recipes.json
@@ -76,6 +76,12 @@
     "BOTH-SUBSCRIPTION-HARD-CANCEL": "grep -rniE 'subscri(be|ption)|auto.renew|membership' --include='*.swift' --include='*.kt' --include='*.java' --include='*.html' --include='*.md' . 2>/dev/null | grep -iE 'call.{0,25}cancel|cancel.{0,25}call|mail.{0,25}cancel|write.{0,25}cancel|cancel.{0,15}(in.person|by.phone|by.mail)'",
     "BOTH-E-EVIDENCE-COMPLIANCE-MISSING": "grep -rniE 'e-evidence|european production order|european preservation order|emergency data production' . 2>/dev/null",
     "BOTH-WITHDRAWAL-BUTTON-MISSING": "grep -rniE 'withdrawal button|withdrawal function|withdraw from contract|distance contract' . 2>/dev/null",
-    "BOTH-GPSR-COMPLIANCE-MISSING": "grep -rniE 'gpsr|general product safety|product safety|manufacturerInfo|safetyWarning' . 2>/dev/null"
+    "BOTH-GPSR-COMPLIANCE-MISSING": "grep -rniE 'gpsr|general product safety|product safety|manufacturerInfo|safetyWarning' . 2>/dev/null",
+    "FLUTTER-PRIVACY-MANIFEST-MISSING": "grep -q 'permission_handler\\|image_picker\\|geolocator\\|firebase_' pubspec.yaml 2>/dev/null && ! find . -name 'PrivacyInfo.xcprivacy' | grep -q .",
+    "RN-OTA-UNDECLARED": "grep -rn 'react-native-code-push\\|CodePush\\.\\|expo-updates' --include='*.ts' --include='*.tsx' --include='*.js' . 2>/dev/null",
+    "RN-PRIVACY-MANIFEST-MISSING": "grep -qE '\"react-native\"|\"expo\"' package.json 2>/dev/null && grep -rn 'Firebase\\|AsyncStorage\\|expo-file-system' --include='*.ts' --include='*.tsx' . 2>/dev/null && ! find . -name 'PrivacyInfo.xcprivacy' | grep -q .",
+    "IONIC-4.2-THIN-WRAPPER": "grep -rlE 'WKWebView|loadRequest|Capacitor|Cordova' --include='*.ts' --include='*.js' --include='*.swift' . 2>/dev/null | wc -l   # then count distinct @capacitor/(status-bar|splash-screen|push-notifications|haptics) markers, fewer than 2 is a thin wrapper",
+    "IONIC-UIWEBVIEW-DEPRECATED": "grep -rn 'UIWebView' --include='*.swift' --include='*.m' . 2>/dev/null",
+    "IONIC-PRIVACY-MANIFEST-MISSING": "grep -rq '@capacitor/\\|Capacitor\\.' --include='*.ts' . 2>/dev/null && ! find . -name 'PrivacyInfo.xcprivacy' | grep -q ."
   }
 }

--- a/data/rejection-patterns.json
+++ b/data/rejection-patterns.json
@@ -10,1199 +10,6 @@
   ],
   "patterns": [
     {
-      "id": "APPLE-2.1-MISSING-DEMO-ACCOUNT",
-      "platform": "apple",
-      "guideline": "2.1",
-      "title": "Account based app without demo credentials",
-      "severity": "critical",
-      "detection": "Login or auth code present (SignInWithApple, OAuth, Auth, login view) but no demo account note found in review metadata or fastlane review_information.",
-      "signals": [
-        "LoginView",
-        "signIn",
-        "AuthService",
-        "OAuth",
-        "Firebase Auth"
-      ],
-      "fix": "Add a working demo account and a live test path to the Notes for Review field before submission."
-    },
-    {
-      "id": "APPLE-2.1-PLACEHOLDER-CONTENT",
-      "platform": "apple",
-      "guideline": "2.1",
-      "title": "Placeholder content in the build",
-      "severity": "high",
-      "detection": "Strings such as lorem ipsum, TODO, FIXME, placeholder, dummy, test data, example.com found in shipped resources.",
-      "signals": [
-        "lorem ipsum",
-        "placeholder",
-        "TODO",
-        "FIXME",
-        "dummy",
-        "example.com"
-      ],
-      "fix": "Replace all placeholder text and assets with real content before submission."
-    },
-    {
-      "id": "APPLE-2.1-STAGING-BACKEND",
-      "platform": "apple",
-      "guideline": "2.1",
-      "title": "Backend points at staging or localhost",
-      "severity": "critical",
-      "detection": "API base URL in the release config contains localhost, 127.0.0.1, staging, dev, or ngrok.",
-      "signals": [
-        "localhost",
-        "127.0.0.1",
-        "staging.",
-        "dev.",
-        "ngrok",
-        "http://"
-      ],
-      "fix": "Point the release build at the live production backend and confirm it stays up during review."
-    },
-    {
-      "id": "APPLE-5.1.1-MISSING-PRIVACY-POLICY",
-      "platform": "apple",
-      "guideline": "5.1.1(i)",
-      "title": "Missing privacy policy",
-      "severity": "critical",
-      "detection": "No privacy policy URL in App Store Connect metadata and no in app privacy link reference in the codebase.",
-      "signals": [
-        "privacyPolicy",
-        "privacy-policy",
-        "PrivacyPolicyURL"
-      ],
-      "fix": "Publish a privacy policy, link it in App Store Connect, and reach it from inside the app."
-    },
-    {
-      "id": "APPLE-5.1.1-VAGUE-PURPOSE-STRING",
-      "platform": "apple",
-      "guideline": "5.1.1(ii)",
-      "title": "Generic or empty permission purpose string",
-      "severity": "high",
-      "detection": "An NSxUsageDescription key in Info.plist is empty or carries a generic value such as needs access or required.",
-      "signals": [
-        "NSCameraUsageDescription",
-        "NSLocationWhenInUseUsageDescription",
-        "NSPhotoLibraryUsageDescription",
-        "NSMicrophoneUsageDescription",
-        "NSContactsUsageDescription"
-      ],
-      "fix": "Write a specific purpose string naming the real feature that uses each permission."
-    },
-    {
-      "id": "APPLE-5.1.1-MISSING-USAGE-DESCRIPTION",
-      "platform": "apple",
-      "guideline": "5.1.1(ii)",
-      "title": "Sensitive framework linked without a usage description",
-      "severity": "critical",
-      "detection": "A sensitive framework or API is referenced in code but the matching NSxUsageDescription key is absent from Info.plist.",
-      "signals": [
-        "AVCaptureDevice",
-        "CLLocationManager",
-        "PHPhotoLibrary",
-        "CNContactStore",
-        "HKHealthStore"
-      ],
-      "fix": "Add the matching usage description key with a specific reason for every sensitive framework used."
-    },
-    {
-      "id": "APPLE-5.1.1-NO-ACCOUNT-DELETION",
-      "platform": "apple",
-      "guideline": "5.1.1(v)",
-      "title": "Account creation without in app account deletion",
-      "severity": "critical",
-      "detection": "Account creation or sign up code present but no delete account flow found.",
-      "signals": [
-        "signUp",
-        "createAccount",
-        "register"
-      ],
-      "counterSignals": [
-        "deleteAccount",
-        "delete_account",
-        "account deletion"
-      ],
-      "fix": "Add an in app account deletion flow for any app that supports account creation."
-    },
-    {
-      "id": "APPLE-5.1.2-MISSING-ATT",
-      "platform": "apple",
-      "guideline": "5.1.2(i)",
-      "title": "Tracking SDK without App Tracking Transparency",
-      "severity": "high",
-      "detection": "A tracking or advertising SDK is present but ATTrackingManager request is not called and NSUserTrackingUsageDescription is absent.",
-      "signals": [
-        "AppsFlyer",
-        "Adjust",
-        "Branch",
-        "FacebookSDK",
-        "IDFA",
-        "ASIdentifierManager"
-      ],
-      "counterSignals": [
-        "ATTrackingManager",
-        "NSUserTrackingUsageDescription"
-      ],
-      "fix": "Call the ATT prompt before any cross app tracking and add the tracking usage description."
-    },
-    {
-      "id": "APPLE-3.1.1-EXTERNAL-PAYMENT",
-      "platform": "apple",
-      "guideline": "3.1.1",
-      "title": "Digital goods sold outside in app purchase",
-      "severity": "critical",
-      "detection": "A web checkout or external payment SDK is used for digital content rather than StoreKit.",
-      "signals": [
-        "Stripe",
-        "PayPal",
-        "checkout",
-        "WKWebView payment",
-        "buy now"
-      ],
-      "counterSignals": [
-        "StoreKit",
-        "SKProduct",
-        "Product.purchase",
-        "in app purchase"
-      ],
-      "fix": "Route all digital goods through StoreKit in app purchase unless the app is a documented exempt category."
-    },
-    {
-      "id": "APPLE-4.8-SOCIAL-LOGIN-ONLY",
-      "platform": "apple",
-      "guideline": "4.8",
-      "title": "Third party social login without an equal alternative",
-      "severity": "high",
-      "detection": "Facebook, Google, or similar social login is present without Sign in with Apple or an equal privacy preserving option.",
-      "signals": [
-        "FacebookLogin",
-        "GoogleSignIn",
-        "GIDSignIn",
-        "LoginWithFacebook"
-      ],
-      "counterSignals": [
-        "SignInWithApple",
-        "ASAuthorizationAppleIDProvider"
-      ],
-      "fix": "Add Sign in with Apple or an equal login that limits data to name and email and allows a private email."
-    },
-    {
-      "id": "APPLE-4.2-WEB-WRAPPER",
-      "platform": "apple",
-      "guideline": "4.2",
-      "title": "Thin web wrapper with no added value",
-      "severity": "high",
-      "detection": "The app is mostly a single web view loading a website with little native code.",
-      "signals": [
-        "WKWebView loadRequest",
-        "single WebView",
-        "Capacitor",
-        "Cordova"
-      ],
-      "fix": "Add native capability, offline value, device integration, or content the web version lacks."
-    },
-    {
-      "id": "APPLE-2.5.1-PRIVATE-API",
-      "platform": "apple",
-      "guideline": "2.5.1",
-      "title": "Private API or deprecated framework use",
-      "severity": "high",
-      "detection": "References to known private API selectors or deprecated frameworks found in the binary or code.",
-      "signals": [
-        "respondsToSelector private",
-        "UIWebView",
-        "performSelector hidden"
-      ],
-      "fix": "Use only documented public APIs and current frameworks."
-    },
-    {
-      "id": "APPLE-2.3-CROSS-PLATFORM-REFERENCE",
-      "platform": "apple",
-      "guideline": "2.3.10",
-      "title": "Reference to other platform or marketplace",
-      "severity": "medium",
-      "detection": "Strings such as Android, Google Play, or alternative marketplace names found in app facing copy or metadata.",
-      "signals": [
-        "Google Play",
-        "available on Android",
-        "download on the Play Store"
-      ],
-      "fix": "Remove references to other platforms and marketplaces from the app and metadata."
-    },
-    {
-      "id": "APPLE-2.3-AGE-RATING-2026",
-      "platform": "apple",
-      "guideline": "2.3.6",
-      "title": "New 2026 age rating questionnaire not answered",
-      "severity": "high",
-      "detection": "Manual check. The updated age rating questions (13 plus, 16 plus, 18 plus) must be answered by 31 January 2026 to submit updates.",
-      "signals": [],
-      "fix": "Answer the updated age rating questionnaire in App Store Connect for every app."
-    },
-    {
-      "id": "APPLE-5.1.2-AI-NO-CONSENT-MODAL",
-      "platform": "apple",
-      "guideline": "5.1.2(i)",
-      "title": "Personal data shared with third party AI without consent modal",
-      "severity": "high",
-      "detection": "A third party AI or LLM SDK is present and personal data may be sent without a consent modal naming the provider.",
-      "signals": [
-        "OpenAI",
-        "anthropic",
-        "gemini",
-        "completion",
-        "chat/completions"
-      ],
-      "counterSignals": [
-        "consent",
-        "data sharing modal"
-      ],
-      "fix": "Show a consent modal naming the AI provider and data types before any personal data leaves the app."
-    },
-    {
-      "id": "GOOGLE-DATASAFETY-MISMATCH",
-      "platform": "google",
-      "guideline": "Data Safety",
-      "title": "Data Safety form does not match runtime behavior",
-      "severity": "critical",
-      "detection": "Analytics, ads, or tracking SDKs are present that collect or share data not declared in the Data Safety section. This is the number one Google rejection cause.",
-      "signals": [
-        "firebase-analytics",
-        "com.google.android.gms.ads",
-        "facebook",
-        "appsflyer",
-        "adjust"
-      ],
-      "fix": "Audit every SDK and runtime data flow and declare every collection, sharing, and security practice accurately in the Data Safety form."
-    },
-    {
-      "id": "GOOGLE-PERM-BACKGROUND-LOCATION",
-      "platform": "google",
-      "guideline": "Permissions and APIs",
-      "title": "Background location without a qualifying core feature",
-      "severity": "critical",
-      "detection": "ACCESS_BACKGROUND_LOCATION declared in AndroidManifest with no clear core feature or prominent disclosure.",
-      "signals": [
-        "ACCESS_BACKGROUND_LOCATION"
-      ],
-      "fix": "Use foreground location where possible, or justify background use with a core feature and a prominent disclosure and the permission declaration."
-    },
-    {
-      "id": "GOOGLE-PERM-ALL-FILES",
-      "platform": "google",
-      "guideline": "Permissions and APIs",
-      "title": "All files access without a qualifying use case",
-      "severity": "critical",
-      "detection": "MANAGE_EXTERNAL_STORAGE declared in AndroidManifest.",
-      "signals": [
-        "MANAGE_EXTERNAL_STORAGE"
-      ],
-      "fix": "Use scoped storage. Request all files access only for a qualifying use case with the required declaration."
-    },
-    {
-      "id": "GOOGLE-PERM-SMS-CALLLOG",
-      "platform": "google",
-      "guideline": "Permissions and APIs",
-      "title": "SMS or Call Log without an approved core use case",
-      "severity": "critical",
-      "detection": "READ_SMS, SEND_SMS, RECEIVE_SMS, READ_CALL_LOG, or WRITE_CALL_LOG declared without an approved use case.",
-      "signals": [
-        "READ_SMS",
-        "SEND_SMS",
-        "RECEIVE_SMS",
-        "READ_CALL_LOG",
-        "WRITE_CALL_LOG"
-      ],
-      "fix": "Use the permissions declaration form for an approved core use case, or drop the permission."
-    },
-    {
-      "id": "GOOGLE-PERM-ACCESSIBILITY-MISUSE",
-      "platform": "google",
-      "guideline": "Permissions and APIs",
-      "title": "AccessibilityService used for non accessibility purposes",
-      "severity": "critical",
-      "detection": "BIND_ACCESSIBILITY_SERVICE declared in an app that is not an accessibility tool.",
-      "signals": [
-        "BIND_ACCESSIBILITY_SERVICE",
-        "AccessibilityService"
-      ],
-      "fix": "Use accessibility APIs only for genuine accessibility features and declare the use, or remove the service."
-    },
-    {
-      "id": "GOOGLE-TARGET-API",
-      "platform": "google",
-      "guideline": "Target API level",
-      "title": "App does not target the current required API level",
-      "severity": "high",
-      "detection": "targetSdkVersion in build.gradle is below the current Google Play requirement. From 31 August 2026, new apps and updates must target Android 16, API level 36, or higher.",
-      "signals": [
-        "targetSdkVersion",
-        "targetSdk"
-      ],
-      "fix": "Build against the current required Android target API level. From 31 August 2026 that is API 36 or higher. Submissions below the threshold are rejected automatically."
-    },
-    {
-      "id": "GOOGLE-12-TESTER-RULE",
-      "platform": "google",
-      "guideline": "Closed testing requirement",
-      "title": "New personal account without the closed test",
-      "severity": "high",
-      "detection": "Manual check. New personal developer accounts need at least 12 testers for 14 consecutive days of closed testing before production.",
-      "signals": [],
-      "fix": "Run the closed test with at least 12 testers over 14 consecutive days, or use an organization account where appropriate."
-    },
-    {
-      "id": "GOOGLE-PLAY-BILLING",
-      "platform": "google",
-      "guideline": "Payments",
-      "title": "Digital goods sold without Play Billing",
-      "severity": "critical",
-      "detection": "A web checkout or third party payment SDK is used for in app digital goods rather than Play Billing.",
-      "signals": [
-        "Stripe",
-        "PayPal",
-        "checkout",
-        "razorpay"
-      ],
-      "counterSignals": [
-        "BillingClient",
-        "Play Billing",
-        "com.android.billingclient"
-      ],
-      "fix": "Use Play Billing for in app digital goods, with regional alternatives only where Google permits."
-    },
-    {
-      "id": "GOOGLE-MISSING-PRIVACY-POLICY",
-      "platform": "google",
-      "guideline": "User Data",
-      "title": "Missing privacy policy",
-      "severity": "critical",
-      "detection": "No privacy policy URL set in the Play Console store listing while the app collects user data.",
-      "signals": [
-        "privacyPolicy",
-        "privacy-policy"
-      ],
-      "fix": "Publish a privacy policy and set its URL in the Play Console store listing."
-    },
-    {
-      "id": "GOOGLE-MISLEADING-LISTING",
-      "platform": "google",
-      "guideline": "Store Listing and Promotion",
-      "title": "Listing claims a feature the app lacks",
-      "severity": "high",
-      "detection": "Manual check. The store listing, screenshots, and description must match the app's actual functionality.",
-      "signals": [],
-      "fix": "Make the listing match the build exactly, with screenshots of real in app screens."
-    },
-    {
-      "id": "GOOGLE-FAMILIES-AD-SDK",
-      "platform": "google",
-      "guideline": "Families",
-      "title": "Non compliant ad SDK in a child targeted app",
-      "severity": "critical",
-      "detection": "An app declared for children uses an ad SDK that is not Families certified, or shows behavioral ads to minors.",
-      "signals": [
-        "children",
-        "Designed for Families",
-        "kids"
-      ],
-      "fix": "Use only Families certified ad SDKs and remove behavioral advertising to minors."
-    },
-    {
-      "id": "BOTH-SDK-SUPPLY-CHAIN",
-      "platform": "both",
-      "guideline": "SDK responsibility",
-      "title": "Third party SDK violates policy on the developer's behalf",
-      "severity": "high",
-      "detection": "A bundled SDK requests permissions, tracks users, or behaves in ways the app does not declare. The developer is responsible for SDK behavior.",
-      "signals": [],
-      "fix": "Vet every SDK, keep them current, and remove any that collect or share data the app does not declare."
-    },
-    {
-      "id": "BOTH-LOOTBOX-ODDS",
-      "platform": "both",
-      "guideline": "Apple 3.1.1, Google gambling",
-      "title": "Random reward mechanic without disclosed odds",
-      "severity": "high",
-      "detection": "Loot box, gacha, or random reward purchase present without odds disclosed before purchase.",
-      "signals": [
-        "lootbox",
-        "loot box",
-        "gacha",
-        "random reward",
-        "mystery box"
-      ],
-      "fix": "Disclose the odds for every random reward before the user purchases."
-    },
-    {
-      "id": "APPLE-PRIVACY-MANIFEST-MISSING",
-      "platform": "apple",
-      "guideline": "Privacy Manifest",
-      "title": "Required reason APIs or third party SDKs without a privacy manifest",
-      "severity": "critical",
-      "detection": "Required reason API usage or a commonly used third party SDK is present but no PrivacyInfo.xcprivacy is bundled, or an SDK lacks its signed manifest. Enforced by Apple at upload since 2024. The top modern Apple upload rejection.",
-      "signals": [
-        "NSFileManager",
-        "UserDefaults",
-        "systemUptime",
-        "ProcessInfo",
-        "Firebase",
-        "Alamofire"
-      ],
-      "counterSignals": [
-        "PrivacyInfo.xcprivacy",
-        "NSPrivacyAccessedAPITypes"
-      ],
-      "fix": "Add a PrivacyInfo.xcprivacy with NSPrivacyAccessedAPITypes and approved reason codes, list NSPrivacyTrackingDomains, and confirm every third party SDK ships its signed manifest."
-    },
-    {
-      "id": "APPLE-EXPORT-COMPLIANCE-MISSING",
-      "platform": "apple",
-      "guideline": "Export compliance",
-      "title": "Missing encryption declaration leaves the build in Missing Compliance",
-      "severity": "high",
-      "detection": "ITSAppUsesNonExemptEncryption is not set in Info.plist, so each submission stalls in Missing Compliance and never reaches review.",
-      "signals": [],
-      "counterSignals": [
-        "ITSAppUsesNonExemptEncryption"
-      ],
-      "fix": "Set ITSAppUsesNonExemptEncryption in Info.plist. The exempt answer applies to a standard HTTPS only app."
-    },
-    {
-      "id": "APPLE-RESTORE-PURCHASES-MISSING",
-      "platform": "apple",
-      "guideline": "3.1.1",
-      "title": "Non consumable purchase without a Restore Purchases control",
-      "severity": "high",
-      "detection": "StoreKit purchases are present but no restore path is found.",
-      "signals": [
-        "SKProduct",
-        "Product.purchase",
-        "StoreKit"
-      ],
-      "counterSignals": [
-        "restorePurchases",
-        "restoreCompletedTransactions",
-        "AppStore.sync",
-        "Restore Purchases"
-      ],
-      "fix": "Add a visible Restore Purchases control. It is required for non consumables and non renewing subscriptions."
-    },
-    {
-      "id": "APPLE-ACCOUNT-DELETION-WEAK",
-      "platform": "apple",
-      "guideline": "5.1.1(v)",
-      "title": "Account deletion is a mailto or deactivate only flow",
-      "severity": "high",
-      "detection": "The only account removal path is a mailto link, a web form the user must leave the app to reach, or a deactivate that does not delete.",
-      "signals": [
-        "mailto:",
-        "deactivate",
-        "contact us to delete"
-      ],
-      "fix": "Provide genuine in app deletion of the account and its data, not a deactivate or an external form."
-    },
-    {
-      "id": "ANDROID-DYNAMIC-CODE-LOADING",
-      "platform": "google",
-      "guideline": "Device and Network Abuse",
-      "title": "Dynamic code loading at runtime",
-      "severity": "high",
-      "detection": "DexClassLoader, PathClassLoader from a downloaded file, or downloading and executing code at runtime.",
-      "signals": [
-        "DexClassLoader",
-        "PathClassLoader",
-        "loadDex",
-        "createPackageContext"
-      ],
-      "fix": "Ship all code in the package. Server side changes must be data, not executable code."
-    },
-    {
-      "id": "ANDROID-QUERY-ALL-PACKAGES",
-      "platform": "google",
-      "guideline": "Package visibility",
-      "title": "QUERY_ALL_PACKAGES without a permitted use case",
-      "severity": "high",
-      "detection": "QUERY_ALL_PACKAGES declared in AndroidManifest.",
-      "signals": [
-        "QUERY_ALL_PACKAGES"
-      ],
-      "fix": "Declare specific packages with a queries element, or qualify for a permitted use case."
-    },
-    {
-      "id": "ANDROID-OVERLAY-TAPJACKING",
-      "platform": "google",
-      "guideline": "Permissions and APIs",
-      "title": "System overlay permission, a tapjacking and malware signal",
-      "severity": "high",
-      "detection": "SYSTEM_ALERT_WINDOW or application overlay declared, especially combined with AccessibilityService.",
-      "signals": [
-        "SYSTEM_ALERT_WINDOW",
-        "TYPE_APPLICATION_OVERLAY"
-      ],
-      "fix": "Remove overlay abuse. The overlay plus accessibility combination is a strong malware signal Google enforces against."
-    },
-    {
-      "id": "ANDROID-ACCOUNT-DELETION-URL",
-      "platform": "google",
-      "guideline": "User Data",
-      "title": "Account creation without in app deletion and a data deletion URL",
-      "severity": "high",
-      "detection": "Account creation present but no in app delete path and no web data deletion URL.",
-      "signals": [
-        "signUp",
-        "createAccount",
-        "register"
-      ],
-      "counterSignals": [
-        "deleteAccount",
-        "delete_account",
-        "account deletion"
-      ],
-      "fix": "Provide in app account deletion and set a public data deletion URL in the Play Console listing."
-    },
-    {
-      "id": "BOTH-AI-GENERATED-CONTENT",
-      "platform": "both",
-      "guideline": "Apple 1.2, Google AI Generated Content",
-      "title": "Generative AI output without moderation or safeguards",
-      "severity": "high",
-      "detection": "A generative AI or image generation integration is present without content filtering, reporting, blocking, age rating, or abuse safeguards. Apple applies UGC rules to AI output. Google has a dedicated AI Generated Content policy.",
-      "signals": [
-        "openai",
-        "anthropic",
-        "stable diffusion",
-        "image generation",
-        "chat/completions",
-        "text-to-image"
-      ],
-      "counterSignals": [
-        "moderation",
-        "report",
-        "block user",
-        "content filter"
-      ],
-      "fix": "Add moderation, reporting, blocking, an accurate age rating, and abuse safeguards. Prevent NSFW, deepfake, face swap, and undress generation."
-    },
-    {
-      "id": "BOTH-METADATA-DECORATION",
-      "platform": "both",
-      "guideline": "Apple 2.3.7, Google Store Listing",
-      "title": "Metadata field overflow or banned decoration",
-      "severity": "medium",
-      "detection": "App name over the limit (Apple 30, Google 30), emoji in the title, all caps, or ranking and price claims such as number one, best, top, or free in the title or icon.",
-      "signals": [],
-      "fix": "Keep each metadata field within its limit and remove emoji, all caps, and ranking or price claims from the title and icon."
-    },
-    {
-      "id": "BOTH-FINGERPRINTING",
-      "platform": "both",
-      "guideline": "Apple 5.1.2, Google Device and Network Abuse",
-      "title": "Device fingerprinting to track users",
-      "severity": "high",
-      "detection": "Building a persistent device fingerprint from hardware or settings to identify users. Apple bans this regardless of ATT consent.",
-      "signals": [
-        "fingerprint",
-        "deviceFingerprint",
-        "canvas fingerprint",
-        "identifierForVendor cross app"
-      ],
-      "fix": "Do not fingerprint. Use the platform advertising identifier with consent where tracking is genuinely needed."
-    },
-    {
-      "id": "APPLE-2.3-FUTURE-FUNCTIONALITY",
-      "platform": "apple",
-      "guideline": "2.3.1",
-      "title": "Metadata promises features that do not ship in this build",
-      "severity": "medium",
-      "detection": "Listing or in app copy uses coming soon, beta, or a promised feature not present in the build. Mirrors the fastlane precheck future_functionality rule.",
-      "signals": [
-        "coming soon",
-        "coming-soon",
-        "beta",
-        "will be available",
-        "in a future update",
-        "stay tuned"
-      ],
-      "fix": "Describe only what the build does today. Remove coming soon and future feature promises from the listing."
-    },
-    {
-      "id": "APPLE-2.3-NEGATIVE-APPLE-SENTIMENT",
-      "platform": "apple",
-      "guideline": "2.3.1",
-      "title": "Metadata names an iOS bug or references Apple negatively",
-      "severity": "medium",
-      "detection": "Listing copy mentions an iOS bug or makes a negative or insensitive reference to Apple. Mirrors the fastlane precheck negative_apple_sentiment rule.",
-      "signals": [
-        "iOS bug",
-        "apple bug",
-        "broken on iOS",
-        "fix for ios bug"
-      ],
-      "fix": "Remove negative references to Apple and iOS bugs from the listing copy."
-    },
-    {
-      "id": "BOTH-UNREACHABLE-METADATA-URL",
-      "platform": "both",
-      "guideline": "Apple 1.5 and 2.1, Google User Data",
-      "title": "Broken support, marketing, or privacy URL in the listing",
-      "severity": "high",
-      "detection": "A support URL, marketing URL, or privacy policy URL in the listing does not load. Mirrors the fastlane precheck unreachable_urls rule.",
-      "signals": [],
-      "fix": "Confirm every listing URL is public and loads during the entire review window."
-    },
-    {
-      "id": "APPLE-5.2.5-APPLE-DEVICE-IMAGE",
-      "platform": "apple",
-      "guideline": "5.2.5",
-      "title": "Apple device image or Apple trademark in the icon or screenshots",
-      "severity": "high",
-      "detection": "Manual metadata check. The app icon or screenshots show an Apple device, the Apple logo, or imply Apple endorsement.",
-      "signals": [],
-      "fix": "Remove Apple device images and Apple marks from the icon and screenshots. Source. truongduy2611 apple_trademark rule."
-    },
-    {
-      "id": "APPLE-2.3.4-DEVICE-FRAMES-PREVIEW",
-      "platform": "apple",
-      "guideline": "2.3.4",
-      "title": "Device frames around the app in a preview video",
-      "severity": "medium",
-      "detection": "Manual metadata check. The app preview video wraps the app in a device frame instead of showing the app full screen.",
-      "signals": [],
-      "fix": "Capture the preview video full screen from the device, without a device frame overlay."
-    },
-    {
-      "id": "APPLE-3.1.2-MISLEADING-PRICING",
-      "platform": "apple",
-      "guideline": "3.1.2",
-      "title": "Subscription shows the per month price more prominently than the billed amount",
-      "severity": "high",
-      "detection": "Manual paywall check. An annual subscription shows a small per month figure large and the actual billed total small.",
-      "signals": [],
-      "fix": "Show the actual amount the user will be charged at least as prominently as any per month figure. Source. truongduy2611 misleading_pricing rule."
-    },
-    {
-      "id": "APPLE-1.2-UGC-24H-ACTION",
-      "platform": "apple",
-      "guideline": "1.2",
-      "title": "User generated content without the 24 hour action mechanism",
-      "severity": "critical",
-      "detection": "UGC present without a EULA with zero tolerance for objectionable content, content filtering, a flag mechanism, user blocking, and the ability to act on a report within 24 hours by removing content and ejecting the user.",
-      "signals": [
-        "post",
-        "comment",
-        "upload",
-        "chat",
-        "feed",
-        "community"
-      ],
-      "counterSignals": [
-        "report",
-        "block user",
-        "EULA",
-        "moderation"
-      ],
-      "fix": "Add a zero tolerance EULA, content filtering, in app reporting, user blocking, and a process to act on reports within 24 hours. Source. real Apple Safety 1.2 rejection email."
-    },
-    {
-      "id": "CHINA-AI-REFERENCES",
-      "platform": "apple",
-      "guideline": "5",
-      "title": "External AI service references in a China storefront",
-      "severity": "high",
-      "detection": "Manual storefront check. References to ChatGPT, Gemini, OpenAI, or similar external AI services in an app distributed on the China storefront can trigger a regional rejection.",
-      "signals": [],
-      "fix": "Remove or localize external AI service references for the China storefront. Source. truongduy2611 china_storefront rule."
-    },
-    {
-      "id": "APPLE-2.4.5-UNUSED-ENTITLEMENTS",
-      "platform": "apple",
-      "guideline": "2.4.5(i)",
-      "title": "Entitlements declared but not used",
-      "severity": "high",
-      "detection": "An entitlements file declares a capability the app does not use. Apple requests justification for any entitlement with no matching functionality, which blocks review. Temporary exception entitlements draw extra scrutiny.",
-      "signals": [
-        "com.apple.security.temporary-exception",
-        ".entitlements"
-      ],
-      "fix": "Remove any entitlement the app does not actively use. Cross check each entitlement against real code usage. Source. truongduy2611 unused_entitlements rule."
-    },
-    {
-      "id": "APPLE-4.0-SIWA-UX",
-      "platform": "apple",
-      "guideline": "4.0",
-      "title": "Sign in with Apple UX violation",
-      "severity": "high",
-      "detection": "Asking for name or email again after Sign in with Apple already provided them, a non standard SIWA button, hiding SIWA below other social logins, or rejecting a private relay email.",
-      "signals": [
-        "ASAuthorizationAppleIDProvider",
-        "SignInWithApple"
-      ],
-      "counterSignals": [
-        "ASAuthorizationAppleIDButton",
-        "privaterelay.appleid.com"
-      ],
-      "fix": "Use the name and email from the Apple credential, do not re ask, use the standard SIWA button, keep SIWA at least as prominent as other logins, and accept private relay emails. Source. truongduy2611 sign_in_with_apple rule."
-    },
-    {
-      "id": "APPLE-5.1.1-UNNECESSARY-DATA",
-      "platform": "apple",
-      "guideline": "5.1.1",
-      "title": "Requiring personal data not relevant to core functionality",
-      "severity": "high",
-      "detection": "A registration or onboarding form requires phone number, gender, marital status, date of birth, or home address when it is not essential to the core feature. Relevance is contextual.",
-      "signals": [
-        "phone",
-        "gender",
-        "marital",
-        "date of birth",
-        "birthdate",
-        "address"
-      ],
-      "fix": "Make non essential personal fields optional. Require only data directly relevant to the core feature. Source. truongduy2611 unnecessary_data rule."
-    },
-    {
-      "id": "APPLE-2.1-DEBUG-FEATURES",
-      "platform": "apple",
-      "guideline": "2.1",
-      "title": "Debug or test features shipped in the production build",
-      "severity": "high",
-      "detection": "Debug menus, test logins, or developer backdoors left visible in the release build rather than gated behind a debug only flag.",
-      "signals": [
-        "debug menu",
-        "debugMenu",
-        "test login",
-        "skip login",
-        "bypass auth",
-        "DEBUG_BYPASS"
-      ],
-      "fix": "Hide debug and test features behind a debug only compile flag so they never ship in production. Source. lukylab checklist."
-    },
-    {
-      "id": "APPLE-2.1-CLOUD-NOT-IN-PRODUCTION",
-      "platform": "apple",
-      "guideline": "2.1",
-      "title": "iCloud or CloudKit schema not deployed to production",
-      "severity": "critical",
-      "detection": "The app uses CloudKit or iCloud but the schema and containers are only in the development environment, so the feature fails for the reviewer on the production build.",
-      "signals": [
-        "CKContainer",
-        "CloudKit",
-        "NSUbiquitousKeyValueStore",
-        "iCloud"
-      ],
-      "fix": "Deploy the CloudKit schema and containers to production before submitting. Source. lukylab checklist."
-    },
-    {
-      "id": "APPLE-2.1-REVIEW-NOTES-INCOMPLETE",
-      "platform": "apple",
-      "guideline": "2.1",
-      "title": "Review notes missing a required section for a new submission",
-      "severity": "high",
-      "detection": "New submission review notes omit one of the six sections. Screen recording on a physical device, app purpose, access instructions and test credentials, external services list, regional differences, and regulated industry documentation.",
-      "signals": [],
-      "fix": "Fill all six review notes sections using templates/REVIEW-NOTES-TEMPLATE.md. Source. truongduy2611 review_notes rules."
-    },
-    {
-      "id": "APPLE-GAMBLING-BRAZIL-LICENSE",
-      "platform": "apple",
-      "guideline": "3.1.1",
-      "title": "Missing Brazilian fixed-odds betting license",
-      "severity": "critical",
-      "detection": "An app that indicates gambling/betting features but does not provide a valid fixed-odds betting license from the Secretariat of Prizes and Bets (SPA) in its App Review Information section when distributing on the Brazil storefront.",
-      "signals": [
-        "gambling",
-        "fixed-odds betting",
-        "Secretariat of Prizes and Bets",
-        "SPA license"
-      ],
-      "fix": "Select 'Yes' to the gambling question in the age rating questionnaire (which automatically sets the Brazil age rating to A18), provide a valid fixed-odds betting license from the Secretariat of Prizes and Bets (SPA) in the App Review Information field, and submit a new app version for verification."
-    },
-    {
-      "id": "GOOGLE-PLAY-AGE-SIGNALS-MISUSE",
-      "platform": "google",
-      "guideline": "User Data",
-      "title": "Misuse of Play Age Signals API",
-      "severity": "critical",
-      "detection": "Usage of the Play Age Signals API (com.google.android.play:age-signals) in conjunction with advertising, marketing, user profiling, or analytics libraries, which violates Google Play's strict Terms of Service.",
-      "signals": [
-        "com.google.android.play:age-signals",
-        "AgeSignalsManager",
-        "AgeSignalsRequest"
-      ],
-      "fix": "Ensure that information from the Play Age Signals API is solely used to provide age-appropriate content and experiences in compliance with laws. Do not use the API or its returned signals for advertising, marketing, user profiling, or analytics."
-    },
-    {
-      "id": "APPLE-PRIVACY-NUTRITION-LABELS",
-      "platform": "apple",
-      "guideline": "5.1.1",
-      "title": "Missing Privacy Nutrition Labels data type declarations",
-      "severity": "high",
-      "detection": "Collecting sensitive user data (e.g. email, phone, name, coordinates) but missing the privacyNutritionLabels declaration or proper nutrition disclosure references.",
-      "signals": [
-        "email",
-        "phoneNumber",
-        "userName",
-        "location",
-        "coordinates"
-      ],
-      "counterSignals": [
-        "NSPrivacyCollectedDataTypes",
-        "privacyNutritionLabels",
-        "privacy-nutrition-labels"
-      ],
-      "fix": "Update the app privacy manifest (PrivacyInfo.xcprivacy) with NSPrivacyCollectedDataTypes and complete corresponding Nutrition Labels in App Store Connect."
-    },
-    {
-      "id": "ANDROID-USER-DATA-DISCLOSURE",
-      "platform": "google",
-      "guideline": "User Data",
-      "title": "Missing prominent disclosure for sensitive user data",
-      "severity": "critical",
-      "detection": "Collecting personal user data (e.g. contacts, SMS, device accounts, files) without a prominent disclosure and explicit user consent block.",
-      "signals": [
-        "contacts",
-        "SMS",
-        "device accounts",
-        "files",
-        "personalData"
-      ],
-      "counterSignals": [
-        "prominent disclosure",
-        "user consent",
-        "privacy consent",
-        "accept policy"
-      ],
-      "fix": "Provide a prominent in-app disclosure before collecting sensitive personal data, and obtain explicit user consent."
-    },
-    {
-      "id": "ANDROID-ADVERTISING-ID",
-      "platform": "google",
-      "guideline": "User Data",
-      "title": "Google Play Advertising ID usage without disclosure or opt-out",
-      "severity": "high",
-      "detection": "Using com.google.android.gms.permission.AD_ID permission or querying GAID but lacking opt-out support or user deletion pathways in code/privacy policy.",
-      "signals": [
-        "com.google.android.gms.permission.AD_ID",
-        "AD_ID",
-        "getAdvertisingIdInfo"
-      ],
-      "counterSignals": [
-        "opt-out",
-        "reset AD_ID",
-        "advertisingIdConsent",
-        "delete AD_ID"
-      ],
-      "fix": "Declare the AD_ID permission in AndroidManifest.xml and handle user opt-out or deletion requests in full compliance with Google Play policy."
-    },
-    {
-      "id": "ANDROID-RUNTIME-PERMISSIONS",
-      "platform": "google",
-      "guideline": "Permissions and APIs",
-      "title": "Sensitive runtime permissions requested without validation",
-      "severity": "high",
-      "detection": "Requesting critical permissions (camera, contacts, storage) without dynamic checks or explicit explanation/rationale to the user.",
-      "signals": [
-        "requestPermissions",
-        "checkSelfPermission",
-        "shouldShowRequestPermissionRationale"
-      ],
-      "counterSignals": [
-        "permission explanation",
-        "showPermissionRationale",
-        "explainPermission"
-      ],
-      "fix": "Check permissions dynamically at runtime, show a clear rationale if denied, and handle denials gracefully."
-    },
-    {
-      "id": "ANDROID-HEALTH-PERMISSIONS",
-      "platform": "google",
-      "guideline": "Permissions and APIs",
-      "title": "Health or fitness data access without Health Connect declaration",
-      "severity": "critical",
-      "detection": "Accessing Health Connect client or querying health permissions (e.g. steps, heart rate) without proper declaration or dedicated health privacy policy.",
-      "signals": [
-        "HealthConnectClient",
-        "com.google.android.gms.permission.HealthConnect",
-        "READ_STEPS",
-        "READ_HEART_RATE"
-      ],
-      "counterSignals": [
-        "healthConnectConsent",
-        "healthPrivacyPolicy",
-        "Health Connect"
-      ],
-      "fix": "Declare Health Connect permissions, complete the console Health Connect form, and maintain a dedicated health privacy policy."
-    },
-    {
-      "id": "WEB-GDPR-COMPLIANCE",
-      "platform": "web",
-      "guideline": "GDPR",
-      "title": "Processing web personal data without GDPR compliance controls",
-      "severity": "critical",
-      "detection": "Collecting or processing personal web data without explicit opt-in controls, privacy policy links, or right to be forgotten (delete) options.",
-      "signals": [
-        "processData",
-        "personalData",
-        "submitForm",
-        "registerWeb",
-        "webForm"
-      ],
-      "counterSignals": [
-        "GDPR",
-        "opt-in",
-        "privacyConsent",
-        "deletePersonalData",
-        "exportData"
-      ],
-      "fix": "Integrate standard GDPR compliance gates including explicit opt-in for data processing and a mechanism for data deletion."
-    },
-    {
-      "id": "WEB-COOKIE-CONSENT",
-      "platform": "web",
-      "guideline": "ePrivacy Directive",
-      "title": "Setting non-essential cookies without prior cookie consent",
-      "severity": "critical",
-      "detection": "Writing to document.cookie or cookieStore without checking if the user accepted cookies via a cookie consent banner.",
-      "signals": [
-        "document.cookie",
-        "setCookie",
-        "cookieStore",
-        "js-cookie",
-        "cookieConsent"
-      ],
-      "counterSignals": [
-        "cookieBanner",
-        "cookieConsentBanner",
-        "acceptCookies",
-        "cookiePreferences"
-      ],
-      "fix": "Implement a compliant Cookie Consent banner that blocks non-essential cookies until the user gives explicit consent."
-    },
-    {
-      "id": "WEB-LOCAL-STORAGE",
-      "platform": "web",
-      "guideline": "GDPR",
-      "title": "Unencrypted sensitive personal data stored in localStorage",
-      "severity": "high",
-      "detection": "Storing sensitive details or JWT tokens in plain text in localStorage without encryption or user consent check.",
-      "signals": [
-        "localStorage.setItem",
-        "localStorage"
-      ],
-      "counterSignals": [
-        "encryptedStorage",
-        "encryptToken",
-        "consentLocalStorage",
-        "clearLocalStorage"
-      ],
-      "fix": "Avoid storing plain sensitive personal info in localStorage, encrypt any stored tokens, and respect storage preferences."
-    },
-    {
-      "id": "WEB-SESSION-STORAGE",
-      "platform": "web",
-      "guideline": "GDPR",
-      "title": "Sensitive session details stored in sessionStorage without protection",
-      "severity": "high",
-      "detection": "Storing raw authentication or session keys in sessionStorage without encryption or clean-up logic.",
-      "signals": [
-        "sessionStorage.setItem",
-        "sessionStorage"
-      ],
-      "counterSignals": [
-        "encryptedSession",
-        "clearSessionStorage"
-      ],
-      "fix": "Limit and secure the data written to sessionStorage, apply encryption, and ensure data is deleted at session end."
-    },
-    {
-      "id": "WEB-INDEXEDDB",
-      "platform": "web",
-      "guideline": "GDPR",
-      "title": "Structured personal data stored in IndexedDB without security controls",
-      "severity": "high",
-      "detection": "Storing user records in IndexedDB without user consent, encryption, or proper deletion lifecycles.",
-      "signals": [
-        "indexedDB.open",
-        "indexedDB",
-        "createObjectStore"
-      ],
-      "counterSignals": [
-        "encryptDatabase",
-        "deleteDatabase",
-        "consentIndexedDB"
-      ],
-      "fix": "Use encrypted IndexedDB wrappers for structured sensitive records, check user consent, and clear databases upon logout."
-    },
-    {
-      "id": "WEB-TRACKING-TECHNOLOGIES",
-      "platform": "web",
-      "guideline": "GDPR",
-      "title": "Third-party tracking technologies loaded without consent",
-      "severity": "high",
-      "detection": "Integrating analytic pixels or tracking scripts (Google Analytics, Facebook Pixel, Hotjar) without consent validation.",
-      "signals": [
-        "gtag",
-        "fbq",
-        "google-analytics",
-        "trackingPixel",
-        "analytics.js",
-        "hotjar"
-      ],
-      "counterSignals": [
-        "consentTracking",
-        "disableTracking",
-        "optOutTracking",
-        "trackingPreferences"
-      ],
-      "fix": "Load third-party tracking scripts and pixels conditionally only after receiving explicit user cookie consent."
-    },
-    {
-      "id": "BOTH-SECURE-STORAGE",
-      "platform": "both",
-      "guideline": "Data Security",
-      "title": "Sensitive tokens or credentials stored in insecure unencrypted formats",
-      "severity": "high",
-      "detection": "Sensitive session credentials or tokens are saved directly to unencrypted plist, UserDefaults, or SharedPreferences instead of Keychain or Android Keystore / EncryptedSharedPreferences.",
-      "signals": [
-        "UserDefaults.standard.set",
-        "getSharedPreferences"
-      ],
-      "fix": "Store all sensitive data and access tokens in iOS Keychain or Android EncryptedSharedPreferences."
-    },
-    {
-      "id": "ANDROID-INSECURE-BACKUP",
-      "platform": "google",
-      "guideline": "Device and Network Abuse",
-      "title": "Android backup is enabled without filtering sensitive data",
-      "severity": "high",
-      "detection": "android:allowBackup is set to true in AndroidManifest.xml without setting data extraction rules to exclude credentials/databases.",
-      "signals": [
-        "allowBackup=\"true\""
-      ],
-      "counterSignals": [
-        "dataExtractionRules",
-        "fullBackupContent",
-        "allowBackup=\"false\""
-      ],
-      "fix": "Disable backups with allowBackup=\"false\", or configure dataExtractionRules / fullBackupContent to exclude sensitive credentials and SQLite databases."
-    },
-    {
-      "id": "BOTH-UNSAFE-DEEPLINK",
-      "platform": "both",
-      "guideline": "Data Security",
-      "title": "Unsafe or unvalidated custom deep link URL schemes used for sensitive operations",
-      "severity": "high",
-      "detection": "Relying on custom URL schemes for sensitive routing, navigation, or passing tokens, without strict input validation.",
-      "signals": [
-        "CFBundleURLSchemes",
-        "android:scheme"
-      ],
-      "counterSignals": [
-        "apple-app-site-association",
-        "assetlinks.json"
-      ],
-      "fix": "Use Universal Links (iOS) and App Links (Android) for secure domain-validated link routing, and sanitize all deep link parameters."
-    },
-    {
-      "id": "APPLE-ACCESSIBILITY-VOICEOVER",
-      "platform": "apple",
-      "guideline": "Design - Accessibility",
-      "title": "VoiceOver support missing or incomplete",
-      "severity": "medium",
-      "detection": "Interactive views or images without accessibilityLabel, accessibilityIdentifier, isAccessibilityElement, or accessibilityElement(children:) properties.",
-      "signals": [
-        "UIAccessibility",
-        "accessibilityLabel",
-        "accessibilityIdentifier",
-        "isAccessibilityElement"
-      ],
-      "fix": "Ensure all interactive components and decorative or informative images have correct accessibility labels, hints, and traits assigned."
-    },
-    {
-      "id": "APPLE-ACCESSIBILITY-DYNAMICTYPE",
-      "platform": "apple",
-      "guideline": "Design - Accessibility",
-      "title": "Dynamic Type support missing or overridden",
-      "severity": "medium",
-      "detection": "Hardcoded font sizes or styles used without matching scaling or preferredFont APIs, or adjustsFontForContentSizeCategory set to false.",
-      "signals": [
-        "UIFont.systemFont",
-        "preferredFont",
-        "adjustsFontForContentSizeCategory"
-      ],
-      "fix": "Use preferredFont(forTextStyle:) in UIKit and system/relative font styles in SwiftUI, ensuring adjustsFontForContentSizeCategory is enabled."
-    },
-    {
-      "id": "APPLE-ACCESSIBILITY-REDUCEMOTION",
-      "platform": "apple",
-      "guideline": "Design - Accessibility",
-      "title": "Reduce Motion accessibility setting ignored",
-      "severity": "medium",
-      "detection": "Custom animations or transitions without checks for UIAccessibility.isReduceMotionEnabled or environment accessibilityReduceMotion.",
-      "signals": [
-        "isReduceMotionEnabled",
-        "accessibilityReduceMotion"
-      ],
-      "fix": "Check the Reduce Motion system status and disable or simplify non-essential animations when requested by the user."
-    },
-    {
-      "id": "APPLE-ACCESSIBILITY-COLORCONTRAST",
-      "platform": "apple",
-      "guideline": "Design - Accessibility",
-      "title": "Color Contrast and system settings ignored",
-      "severity": "medium",
-      "detection": "Hardcoded custom colors used without supporting dark/light mode, high-contrast settings, or checking isDarkerSystemColorsEnabled.",
-      "signals": [
-        "isDarkerSystemColorsEnabled",
-        "darkerSystemColors"
-      ],
-      "fix": "Use dynamic or system colors that automatically adapt, or monitor isDarkerSystemColorsEnabled to adjust contrast dynamically."
-    },
-    {
-      "id": "APPLE-ACCESSIBILITY-HAPTICS",
-      "platform": "apple",
-      "guideline": "Design - Accessibility",
-      "title": "Haptics tactile feedback missing on interactions",
-      "severity": "medium",
-      "detection": "Interactive elements, buttons, or custom controls lacking feedback generators or CoreHaptics calls.",
-      "signals": [
-        "UIImpactFeedbackGenerator",
-        "UINotificationFeedbackGenerator",
-        "UISelectionFeedbackGenerator",
-        "CHHapticEngine"
-      ],
-      "fix": "Add haptic feedback to buttons, toggles, and swipe actions using UIImpactFeedbackGenerator or selection feedback."
-    },
-    {
-      "id": "APPLE-ACCESSIBILITY-KEYBOARD",
-      "platform": "apple",
-      "guideline": "Design - Accessibility",
-      "title": "Keyboard navigation and focus state support missing",
-      "severity": "medium",
-      "detection": "Custom text editors or complex navigation flows missing keyCommands, focusState, or focusable modifiers.",
-      "signals": [
-        "keyCommands",
-        "UIKeyCommand",
-        "FocusState",
-        "focusable"
-      ],
-      "fix": "Support physical keyboard navigation by utilizing keyCommands in UIKit or focusable() and @FocusState in SwiftUI."
-    },
-    {
-      "id": "ANDROID-ACCESSIBILITY-TALKBACK",
-      "platform": "google",
-      "guideline": "User Experience - Accessibility",
-      "title": "TalkBack support missing or disabled",
-      "severity": "medium",
-      "detection": "Views or graphic components missing contentDescription or setting importantForAccessibility inappropriately.",
-      "signals": [
-        "contentDescription",
-        "importantForAccessibility"
-      ],
-      "fix": "Provide meaningful contentDescription values for all informative images and interactive views, and ensure importantForAccessibility is set correctly."
-    },
-    {
       "id": "ANDROID-ACCESSIBILITY-FONTSCALING",
       "platform": "google",
       "guideline": "User Experience - Accessibility",
@@ -1245,22 +52,810 @@
       "fix": "Ensure all interactive elements have a minimum touch target area of 48dp x 48dp by using padding, minWidth, and minHeight."
     },
     {
-      "id": "BOTH-SUBSCRIPTION-HARD-CANCEL",
-      "platform": "both",
-      "guideline": "Apple 3.1.2 subscription terms, US FTC Section 5 / ROSCA, state subscription-cancellation statutes (California, New York, Massachusetts)",
-      "title": "Subscription cancellation requires a phone call, mail, or in-person visit while sign-up is a single tap",
-      "severity": "high",
-      "detection": "A subscription billed outside Apple in-app purchase or Google Play Billing (a web or account-settings cancellation path) directs the person to call, mail, or visit in person to cancel, instead of a self-service in-app or web cancel action. The federal FTC click-to-cancel rule was vacated in 2025 but California, New York, and Massachusetts have their own negative-option statutes in force, and the FTC retains Section 5 and ROSCA authority regardless.",
+      "id": "ANDROID-ACCESSIBILITY-TALKBACK",
+      "platform": "google",
+      "guideline": "User Experience - Accessibility",
+      "title": "TalkBack support missing or disabled",
+      "severity": "medium",
+      "detection": "Views or graphic components missing contentDescription or setting importantForAccessibility inappropriately.",
       "signals": [
-        "call us to cancel",
-        "call to cancel",
-        "cancel your subscription by calling",
-        "mail a letter to cancel",
-        "write to cancel",
-        "cancel in person",
-        "visit a store to cancel"
+        "contentDescription",
+        "importantForAccessibility"
       ],
-      "fix": "Provide a self-service cancellation path (in-app button or account-settings web page) that is at least as easy as sign-up. Never require a phone call, a mailed letter, or an in-person visit to cancel a subscription billed outside the app stores' own billing."
+      "fix": "Provide meaningful contentDescription values for all informative images and interactive views, and ensure importantForAccessibility is set correctly."
+    },
+    {
+      "id": "ANDROID-ACCOUNT-DELETION-URL",
+      "platform": "google",
+      "guideline": "User Data",
+      "title": "Account creation without in app deletion and a data deletion URL",
+      "severity": "high",
+      "detection": "Account creation present but no in app delete path and no web data deletion URL.",
+      "signals": [
+        "signUp",
+        "createAccount",
+        "register"
+      ],
+      "counterSignals": [
+        "deleteAccount",
+        "delete_account",
+        "account deletion"
+      ],
+      "fix": "Provide in app account deletion and set a public data deletion URL in the Play Console listing."
+    },
+    {
+      "id": "ANDROID-ADVERTISING-ID",
+      "platform": "google",
+      "guideline": "User Data",
+      "title": "Google Play Advertising ID usage without disclosure or opt-out",
+      "severity": "high",
+      "detection": "Using com.google.android.gms.permission.AD_ID permission or querying GAID but lacking opt-out support or user deletion pathways in code/privacy policy.",
+      "signals": [
+        "com.google.android.gms.permission.AD_ID",
+        "AD_ID",
+        "getAdvertisingIdInfo"
+      ],
+      "counterSignals": [
+        "opt-out",
+        "reset AD_ID",
+        "advertisingIdConsent",
+        "delete AD_ID"
+      ],
+      "fix": "Declare the AD_ID permission in AndroidManifest.xml and handle user opt-out or deletion requests in full compliance with Google Play policy."
+    },
+    {
+      "id": "ANDROID-DYNAMIC-CODE-LOADING",
+      "platform": "google",
+      "guideline": "Device and Network Abuse",
+      "title": "Dynamic code loading at runtime",
+      "severity": "high",
+      "detection": "DexClassLoader, PathClassLoader from a downloaded file, or downloading and executing code at runtime.",
+      "signals": [
+        "DexClassLoader",
+        "PathClassLoader",
+        "loadDex",
+        "createPackageContext"
+      ],
+      "fix": "Ship all code in the package. Server side changes must be data, not executable code."
+    },
+    {
+      "id": "ANDROID-HEALTH-PERMISSIONS",
+      "platform": "google",
+      "guideline": "Permissions and APIs",
+      "title": "Health or fitness data access without Health Connect declaration",
+      "severity": "critical",
+      "detection": "Accessing Health Connect client or querying health permissions (e.g. steps, heart rate) without proper declaration or dedicated health privacy policy.",
+      "signals": [
+        "HealthConnectClient",
+        "com.google.android.gms.permission.HealthConnect",
+        "READ_STEPS",
+        "READ_HEART_RATE"
+      ],
+      "counterSignals": [
+        "healthConnectConsent",
+        "healthPrivacyPolicy",
+        "Health Connect"
+      ],
+      "fix": "Declare Health Connect permissions, complete the console Health Connect form, and maintain a dedicated health privacy policy."
+    },
+    {
+      "id": "ANDROID-INSECURE-BACKUP",
+      "platform": "google",
+      "guideline": "Device and Network Abuse",
+      "title": "Android backup is enabled without filtering sensitive data",
+      "severity": "high",
+      "detection": "android:allowBackup is set to true in AndroidManifest.xml without setting data extraction rules to exclude credentials/databases.",
+      "signals": [
+        "allowBackup=\"true\""
+      ],
+      "counterSignals": [
+        "dataExtractionRules",
+        "fullBackupContent",
+        "allowBackup=\"false\""
+      ],
+      "fix": "Disable backups with allowBackup=\"false\", or configure dataExtractionRules / fullBackupContent to exclude sensitive credentials and SQLite databases."
+    },
+    {
+      "id": "ANDROID-OVERLAY-TAPJACKING",
+      "platform": "google",
+      "guideline": "Permissions and APIs",
+      "title": "System overlay permission, a tapjacking and malware signal",
+      "severity": "high",
+      "detection": "SYSTEM_ALERT_WINDOW or application overlay declared, especially combined with AccessibilityService.",
+      "signals": [
+        "SYSTEM_ALERT_WINDOW",
+        "TYPE_APPLICATION_OVERLAY"
+      ],
+      "fix": "Remove overlay abuse. The overlay plus accessibility combination is a strong malware signal Google enforces against."
+    },
+    {
+      "id": "ANDROID-QUERY-ALL-PACKAGES",
+      "platform": "google",
+      "guideline": "Package visibility",
+      "title": "QUERY_ALL_PACKAGES without a permitted use case",
+      "severity": "high",
+      "detection": "QUERY_ALL_PACKAGES declared in AndroidManifest.",
+      "signals": [
+        "QUERY_ALL_PACKAGES"
+      ],
+      "fix": "Declare specific packages with a queries element, or qualify for a permitted use case."
+    },
+    {
+      "id": "ANDROID-RUNTIME-PERMISSIONS",
+      "platform": "google",
+      "guideline": "Permissions and APIs",
+      "title": "Sensitive runtime permissions requested without validation",
+      "severity": "high",
+      "detection": "Requesting critical permissions (camera, contacts, storage) without dynamic checks or explicit explanation/rationale to the user.",
+      "signals": [
+        "requestPermissions",
+        "checkSelfPermission",
+        "shouldShowRequestPermissionRationale"
+      ],
+      "counterSignals": [
+        "permission explanation",
+        "showPermissionRationale",
+        "explainPermission"
+      ],
+      "fix": "Check permissions dynamically at runtime, show a clear rationale if denied, and handle denials gracefully."
+    },
+    {
+      "id": "ANDROID-USER-DATA-DISCLOSURE",
+      "platform": "google",
+      "guideline": "User Data",
+      "title": "Missing prominent disclosure for sensitive user data",
+      "severity": "critical",
+      "detection": "Collecting personal user data (e.g. contacts, SMS, device accounts, files) without a prominent disclosure and explicit user consent block.",
+      "signals": [
+        "contacts",
+        "SMS",
+        "device accounts",
+        "files",
+        "personalData"
+      ],
+      "counterSignals": [
+        "prominent disclosure",
+        "user consent",
+        "privacy consent",
+        "accept policy"
+      ],
+      "fix": "Provide a prominent in-app disclosure before collecting sensitive personal data, and obtain explicit user consent."
+    },
+    {
+      "id": "APPLE-1.2-UGC-24H-ACTION",
+      "platform": "apple",
+      "guideline": "1.2",
+      "title": "User generated content without the 24 hour action mechanism",
+      "severity": "critical",
+      "detection": "UGC present without a EULA with zero tolerance for objectionable content, content filtering, a flag mechanism, user blocking, and the ability to act on a report within 24 hours by removing content and ejecting the user.",
+      "signals": [
+        "post",
+        "comment",
+        "upload",
+        "chat",
+        "feed",
+        "community"
+      ],
+      "counterSignals": [
+        "report",
+        "block user",
+        "EULA",
+        "moderation"
+      ],
+      "fix": "Add a zero tolerance EULA, content filtering, in app reporting, user blocking, and a process to act on reports within 24 hours. Source. real Apple Safety 1.2 rejection email."
+    },
+    {
+      "id": "APPLE-2.1-CLOUD-NOT-IN-PRODUCTION",
+      "platform": "apple",
+      "guideline": "2.1",
+      "title": "iCloud or CloudKit schema not deployed to production",
+      "severity": "critical",
+      "detection": "The app uses CloudKit or iCloud but the schema and containers are only in the development environment, so the feature fails for the reviewer on the production build.",
+      "signals": [
+        "CKContainer",
+        "CloudKit",
+        "NSUbiquitousKeyValueStore",
+        "iCloud"
+      ],
+      "fix": "Deploy the CloudKit schema and containers to production before submitting. Source. lukylab checklist."
+    },
+    {
+      "id": "APPLE-2.1-DEBUG-FEATURES",
+      "platform": "apple",
+      "guideline": "2.1",
+      "title": "Debug or test features shipped in the production build",
+      "severity": "high",
+      "detection": "Debug menus, test logins, or developer backdoors left visible in the release build rather than gated behind a debug only flag.",
+      "signals": [
+        "debug menu",
+        "debugMenu",
+        "test login",
+        "skip login",
+        "bypass auth",
+        "DEBUG_BYPASS"
+      ],
+      "fix": "Hide debug and test features behind a debug only compile flag so they never ship in production. Source. lukylab checklist."
+    },
+    {
+      "id": "APPLE-2.1-MISSING-DEMO-ACCOUNT",
+      "platform": "apple",
+      "guideline": "2.1",
+      "title": "Account based app without demo credentials",
+      "severity": "critical",
+      "detection": "Login or auth code present (SignInWithApple, OAuth, Auth, login view) but no demo account note found in review metadata or fastlane review_information.",
+      "signals": [
+        "LoginView",
+        "signIn",
+        "AuthService",
+        "OAuth",
+        "Firebase Auth"
+      ],
+      "fix": "Add a working demo account and a live test path to the Notes for Review field before submission."
+    },
+    {
+      "id": "APPLE-2.1-PLACEHOLDER-CONTENT",
+      "platform": "apple",
+      "guideline": "2.1",
+      "title": "Placeholder content in the build",
+      "severity": "high",
+      "detection": "Strings such as lorem ipsum, TODO, FIXME, placeholder, dummy, test data, example.com found in shipped resources.",
+      "signals": [
+        "lorem ipsum",
+        "placeholder",
+        "TODO",
+        "FIXME",
+        "dummy",
+        "example.com"
+      ],
+      "fix": "Replace all placeholder text and assets with real content before submission."
+    },
+    {
+      "id": "APPLE-2.1-REVIEW-NOTES-INCOMPLETE",
+      "platform": "apple",
+      "guideline": "2.1",
+      "title": "Review notes missing a required section for a new submission",
+      "severity": "high",
+      "detection": "New submission review notes omit one of the six sections. Screen recording on a physical device, app purpose, access instructions and test credentials, external services list, regional differences, and regulated industry documentation.",
+      "signals": [],
+      "fix": "Fill all six review notes sections using templates/REVIEW-NOTES-TEMPLATE.md. Source. truongduy2611 review_notes rules."
+    },
+    {
+      "id": "APPLE-2.1-STAGING-BACKEND",
+      "platform": "apple",
+      "guideline": "2.1",
+      "title": "Backend points at staging or localhost",
+      "severity": "critical",
+      "detection": "API base URL in the release config contains localhost, 127.0.0.1, staging, dev, or ngrok.",
+      "signals": [
+        "localhost",
+        "127.0.0.1",
+        "staging.",
+        "dev.",
+        "ngrok",
+        "http://"
+      ],
+      "fix": "Point the release build at the live production backend and confirm it stays up during review."
+    },
+    {
+      "id": "APPLE-2.3-AGE-RATING-2026",
+      "platform": "apple",
+      "guideline": "2.3.6",
+      "title": "New 2026 age rating questionnaire not answered",
+      "severity": "high",
+      "detection": "Manual check. The updated age rating questions (13 plus, 16 plus, 18 plus) must be answered by 31 January 2026 to submit updates.",
+      "signals": [],
+      "fix": "Answer the updated age rating questionnaire in App Store Connect for every app."
+    },
+    {
+      "id": "APPLE-2.3-CROSS-PLATFORM-REFERENCE",
+      "platform": "apple",
+      "guideline": "2.3.10",
+      "title": "Reference to other platform or marketplace",
+      "severity": "medium",
+      "detection": "Strings such as Android, Google Play, or alternative marketplace names found in app facing copy or metadata.",
+      "signals": [
+        "Google Play",
+        "available on Android",
+        "download on the Play Store"
+      ],
+      "fix": "Remove references to other platforms and marketplaces from the app and metadata."
+    },
+    {
+      "id": "APPLE-2.3-FUTURE-FUNCTIONALITY",
+      "platform": "apple",
+      "guideline": "2.3.1",
+      "title": "Metadata promises features that do not ship in this build",
+      "severity": "medium",
+      "detection": "Listing or in app copy uses coming soon, beta, or a promised feature not present in the build. Mirrors the fastlane precheck future_functionality rule.",
+      "signals": [
+        "coming soon",
+        "coming-soon",
+        "beta",
+        "will be available",
+        "in a future update",
+        "stay tuned"
+      ],
+      "fix": "Describe only what the build does today. Remove coming soon and future feature promises from the listing."
+    },
+    {
+      "id": "APPLE-2.3-NEGATIVE-APPLE-SENTIMENT",
+      "platform": "apple",
+      "guideline": "2.3.1",
+      "title": "Metadata names an iOS bug or references Apple negatively",
+      "severity": "medium",
+      "detection": "Listing copy mentions an iOS bug or makes a negative or insensitive reference to Apple. Mirrors the fastlane precheck negative_apple_sentiment rule.",
+      "signals": [
+        "iOS bug",
+        "apple bug",
+        "broken on iOS",
+        "fix for ios bug"
+      ],
+      "fix": "Remove negative references to Apple and iOS bugs from the listing copy."
+    },
+    {
+      "id": "APPLE-2.3.4-DEVICE-FRAMES-PREVIEW",
+      "platform": "apple",
+      "guideline": "2.3.4",
+      "title": "Device frames around the app in a preview video",
+      "severity": "medium",
+      "detection": "Manual metadata check. The app preview video wraps the app in a device frame instead of showing the app full screen.",
+      "signals": [],
+      "fix": "Capture the preview video full screen from the device, without a device frame overlay."
+    },
+    {
+      "id": "APPLE-2.4.5-UNUSED-ENTITLEMENTS",
+      "platform": "apple",
+      "guideline": "2.4.5(i)",
+      "title": "Entitlements declared but not used",
+      "severity": "high",
+      "detection": "An entitlements file declares a capability the app does not use. Apple requests justification for any entitlement with no matching functionality, which blocks review. Temporary exception entitlements draw extra scrutiny.",
+      "signals": [
+        "com.apple.security.temporary-exception",
+        ".entitlements"
+      ],
+      "fix": "Remove any entitlement the app does not actively use. Cross check each entitlement against real code usage. Source. truongduy2611 unused_entitlements rule."
+    },
+    {
+      "id": "APPLE-2.5.1-PRIVATE-API",
+      "platform": "apple",
+      "guideline": "2.5.1",
+      "title": "Private API or deprecated framework use",
+      "severity": "high",
+      "detection": "References to known private API selectors or deprecated frameworks found in the binary or code.",
+      "signals": [
+        "respondsToSelector private",
+        "UIWebView",
+        "performSelector hidden"
+      ],
+      "fix": "Use only documented public APIs and current frameworks."
+    },
+    {
+      "id": "APPLE-3.1.1-EXTERNAL-PAYMENT",
+      "platform": "apple",
+      "guideline": "3.1.1",
+      "title": "Digital goods sold outside in app purchase",
+      "severity": "critical",
+      "detection": "A web checkout or external payment SDK is used for digital content rather than StoreKit.",
+      "signals": [
+        "Stripe",
+        "PayPal",
+        "checkout",
+        "WKWebView payment",
+        "buy now"
+      ],
+      "counterSignals": [
+        "StoreKit",
+        "SKProduct",
+        "Product.purchase",
+        "in app purchase"
+      ],
+      "fix": "Route all digital goods through StoreKit in app purchase unless the app is a documented exempt category."
+    },
+    {
+      "id": "APPLE-3.1.2-MISLEADING-PRICING",
+      "platform": "apple",
+      "guideline": "3.1.2",
+      "title": "Subscription shows the per month price more prominently than the billed amount",
+      "severity": "high",
+      "detection": "Manual paywall check. An annual subscription shows a small per month figure large and the actual billed total small.",
+      "signals": [],
+      "fix": "Show the actual amount the user will be charged at least as prominently as any per month figure. Source. truongduy2611 misleading_pricing rule."
+    },
+    {
+      "id": "APPLE-4.0-SIWA-UX",
+      "platform": "apple",
+      "guideline": "4.0",
+      "title": "Sign in with Apple UX violation",
+      "severity": "high",
+      "detection": "Asking for name or email again after Sign in with Apple already provided them, a non standard SIWA button, hiding SIWA below other social logins, or rejecting a private relay email.",
+      "signals": [
+        "ASAuthorizationAppleIDProvider",
+        "SignInWithApple"
+      ],
+      "counterSignals": [
+        "ASAuthorizationAppleIDButton",
+        "privaterelay.appleid.com"
+      ],
+      "fix": "Use the name and email from the Apple credential, do not re ask, use the standard SIWA button, keep SIWA at least as prominent as other logins, and accept private relay emails. Source. truongduy2611 sign_in_with_apple rule."
+    },
+    {
+      "id": "APPLE-4.2-WEB-WRAPPER",
+      "platform": "apple",
+      "guideline": "4.2",
+      "title": "Thin web wrapper with no added value",
+      "severity": "high",
+      "detection": "The app is mostly a single web view loading a website with little native code.",
+      "signals": [
+        "WKWebView loadRequest",
+        "single WebView",
+        "Capacitor",
+        "Cordova"
+      ],
+      "fix": "Add native capability, offline value, device integration, or content the web version lacks."
+    },
+    {
+      "id": "APPLE-4.8-SOCIAL-LOGIN-ONLY",
+      "platform": "apple",
+      "guideline": "4.8",
+      "title": "Third party social login without an equal alternative",
+      "severity": "high",
+      "detection": "Facebook, Google, or similar social login is present without Sign in with Apple or an equal privacy preserving option.",
+      "signals": [
+        "FacebookLogin",
+        "GoogleSignIn",
+        "GIDSignIn",
+        "LoginWithFacebook"
+      ],
+      "counterSignals": [
+        "SignInWithApple",
+        "ASAuthorizationAppleIDProvider"
+      ],
+      "fix": "Add Sign in with Apple or an equal login that limits data to name and email and allows a private email."
+    },
+    {
+      "id": "APPLE-5.1.1-MISSING-PRIVACY-POLICY",
+      "platform": "apple",
+      "guideline": "5.1.1(i)",
+      "title": "Missing privacy policy",
+      "severity": "critical",
+      "detection": "No privacy policy URL in App Store Connect metadata and no in app privacy link reference in the codebase.",
+      "signals": [
+        "privacyPolicy",
+        "privacy-policy",
+        "PrivacyPolicyURL"
+      ],
+      "fix": "Publish a privacy policy, link it in App Store Connect, and reach it from inside the app."
+    },
+    {
+      "id": "APPLE-5.1.1-MISSING-USAGE-DESCRIPTION",
+      "platform": "apple",
+      "guideline": "5.1.1(ii)",
+      "title": "Sensitive framework linked without a usage description",
+      "severity": "critical",
+      "detection": "A sensitive framework or API is referenced in code but the matching NSxUsageDescription key is absent from Info.plist.",
+      "signals": [
+        "AVCaptureDevice",
+        "CLLocationManager",
+        "PHPhotoLibrary",
+        "CNContactStore",
+        "HKHealthStore"
+      ],
+      "fix": "Add the matching usage description key with a specific reason for every sensitive framework used."
+    },
+    {
+      "id": "APPLE-5.1.1-NO-ACCOUNT-DELETION",
+      "platform": "apple",
+      "guideline": "5.1.1(v)",
+      "title": "Account creation without in app account deletion",
+      "severity": "critical",
+      "detection": "Account creation or sign up code present but no delete account flow found.",
+      "signals": [
+        "signUp",
+        "createAccount",
+        "register"
+      ],
+      "counterSignals": [
+        "deleteAccount",
+        "delete_account",
+        "account deletion"
+      ],
+      "fix": "Add an in app account deletion flow for any app that supports account creation."
+    },
+    {
+      "id": "APPLE-5.1.1-UNNECESSARY-DATA",
+      "platform": "apple",
+      "guideline": "5.1.1",
+      "title": "Requiring personal data not relevant to core functionality",
+      "severity": "high",
+      "detection": "A registration or onboarding form requires phone number, gender, marital status, date of birth, or home address when it is not essential to the core feature. Relevance is contextual.",
+      "signals": [
+        "phone",
+        "gender",
+        "marital",
+        "date of birth",
+        "birthdate",
+        "address"
+      ],
+      "fix": "Make non essential personal fields optional. Require only data directly relevant to the core feature. Source. truongduy2611 unnecessary_data rule."
+    },
+    {
+      "id": "APPLE-5.1.1-VAGUE-PURPOSE-STRING",
+      "platform": "apple",
+      "guideline": "5.1.1(ii)",
+      "title": "Generic or empty permission purpose string",
+      "severity": "high",
+      "detection": "An NSxUsageDescription key in Info.plist is empty or carries a generic value such as needs access or required.",
+      "signals": [
+        "NSCameraUsageDescription",
+        "NSLocationWhenInUseUsageDescription",
+        "NSPhotoLibraryUsageDescription",
+        "NSMicrophoneUsageDescription",
+        "NSContactsUsageDescription"
+      ],
+      "fix": "Write a specific purpose string naming the real feature that uses each permission."
+    },
+    {
+      "id": "APPLE-5.1.2-AI-NO-CONSENT-MODAL",
+      "platform": "apple",
+      "guideline": "5.1.2(i)",
+      "title": "Personal data shared with third party AI without consent modal",
+      "severity": "high",
+      "detection": "A third party AI or LLM SDK is present and personal data may be sent without a consent modal naming the provider.",
+      "signals": [
+        "OpenAI",
+        "anthropic",
+        "gemini",
+        "completion",
+        "chat/completions"
+      ],
+      "counterSignals": [
+        "consent",
+        "data sharing modal"
+      ],
+      "fix": "Show a consent modal naming the AI provider and data types before any personal data leaves the app."
+    },
+    {
+      "id": "APPLE-5.1.2-MISSING-ATT",
+      "platform": "apple",
+      "guideline": "5.1.2(i)",
+      "title": "Tracking SDK without App Tracking Transparency",
+      "severity": "high",
+      "detection": "A tracking or advertising SDK is present but ATTrackingManager request is not called and NSUserTrackingUsageDescription is absent.",
+      "signals": [
+        "AppsFlyer",
+        "Adjust",
+        "Branch",
+        "FacebookSDK",
+        "IDFA",
+        "ASIdentifierManager"
+      ],
+      "counterSignals": [
+        "ATTrackingManager",
+        "NSUserTrackingUsageDescription"
+      ],
+      "fix": "Call the ATT prompt before any cross app tracking and add the tracking usage description."
+    },
+    {
+      "id": "APPLE-5.2.5-APPLE-DEVICE-IMAGE",
+      "platform": "apple",
+      "guideline": "5.2.5",
+      "title": "Apple device image or Apple trademark in the icon or screenshots",
+      "severity": "high",
+      "detection": "Manual metadata check. The app icon or screenshots show an Apple device, the Apple logo, or imply Apple endorsement.",
+      "signals": [],
+      "fix": "Remove Apple device images and Apple marks from the icon and screenshots. Source. truongduy2611 apple_trademark rule."
+    },
+    {
+      "id": "APPLE-ACCESSIBILITY-COLORCONTRAST",
+      "platform": "apple",
+      "guideline": "Design - Accessibility",
+      "title": "Color Contrast and system settings ignored",
+      "severity": "medium",
+      "detection": "Hardcoded custom colors used without supporting dark/light mode, high-contrast settings, or checking isDarkerSystemColorsEnabled.",
+      "signals": [
+        "isDarkerSystemColorsEnabled",
+        "darkerSystemColors"
+      ],
+      "fix": "Use dynamic or system colors that automatically adapt, or monitor isDarkerSystemColorsEnabled to adjust contrast dynamically."
+    },
+    {
+      "id": "APPLE-ACCESSIBILITY-DYNAMICTYPE",
+      "platform": "apple",
+      "guideline": "Design - Accessibility",
+      "title": "Dynamic Type support missing or overridden",
+      "severity": "medium",
+      "detection": "Hardcoded font sizes or styles used without matching scaling or preferredFont APIs, or adjustsFontForContentSizeCategory set to false.",
+      "signals": [
+        "UIFont.systemFont",
+        "preferredFont",
+        "adjustsFontForContentSizeCategory"
+      ],
+      "fix": "Use preferredFont(forTextStyle:) in UIKit and system/relative font styles in SwiftUI, ensuring adjustsFontForContentSizeCategory is enabled."
+    },
+    {
+      "id": "APPLE-ACCESSIBILITY-HAPTICS",
+      "platform": "apple",
+      "guideline": "Design - Accessibility",
+      "title": "Haptics tactile feedback missing on interactions",
+      "severity": "medium",
+      "detection": "Interactive elements, buttons, or custom controls lacking feedback generators or CoreHaptics calls.",
+      "signals": [
+        "UIImpactFeedbackGenerator",
+        "UINotificationFeedbackGenerator",
+        "UISelectionFeedbackGenerator",
+        "CHHapticEngine"
+      ],
+      "fix": "Add haptic feedback to buttons, toggles, and swipe actions using UIImpactFeedbackGenerator or selection feedback."
+    },
+    {
+      "id": "APPLE-ACCESSIBILITY-KEYBOARD",
+      "platform": "apple",
+      "guideline": "Design - Accessibility",
+      "title": "Keyboard navigation and focus state support missing",
+      "severity": "medium",
+      "detection": "Custom text editors or complex navigation flows missing keyCommands, focusState, or focusable modifiers.",
+      "signals": [
+        "keyCommands",
+        "UIKeyCommand",
+        "FocusState",
+        "focusable"
+      ],
+      "fix": "Support physical keyboard navigation by utilizing keyCommands in UIKit or focusable() and @FocusState in SwiftUI."
+    },
+    {
+      "id": "APPLE-ACCESSIBILITY-REDUCEMOTION",
+      "platform": "apple",
+      "guideline": "Design - Accessibility",
+      "title": "Reduce Motion accessibility setting ignored",
+      "severity": "medium",
+      "detection": "Custom animations or transitions without checks for UIAccessibility.isReduceMotionEnabled or environment accessibilityReduceMotion.",
+      "signals": [
+        "isReduceMotionEnabled",
+        "accessibilityReduceMotion"
+      ],
+      "fix": "Check the Reduce Motion system status and disable or simplify non-essential animations when requested by the user."
+    },
+    {
+      "id": "APPLE-ACCESSIBILITY-VOICEOVER",
+      "platform": "apple",
+      "guideline": "Design - Accessibility",
+      "title": "VoiceOver support missing or incomplete",
+      "severity": "medium",
+      "detection": "Interactive views or images without accessibilityLabel, accessibilityIdentifier, isAccessibilityElement, or accessibilityElement(children:) properties.",
+      "signals": [
+        "UIAccessibility",
+        "accessibilityLabel",
+        "accessibilityIdentifier",
+        "isAccessibilityElement"
+      ],
+      "fix": "Ensure all interactive components and decorative or informative images have correct accessibility labels, hints, and traits assigned."
+    },
+    {
+      "id": "APPLE-ACCOUNT-DELETION-WEAK",
+      "platform": "apple",
+      "guideline": "5.1.1(v)",
+      "title": "Account deletion is a mailto or deactivate only flow",
+      "severity": "high",
+      "detection": "The only account removal path is a mailto link, a web form the user must leave the app to reach, or a deactivate that does not delete.",
+      "signals": [
+        "mailto:",
+        "deactivate",
+        "contact us to delete"
+      ],
+      "fix": "Provide genuine in app deletion of the account and its data, not a deactivate or an external form."
+    },
+    {
+      "id": "APPLE-EXPORT-COMPLIANCE-MISSING",
+      "platform": "apple",
+      "guideline": "Export compliance",
+      "title": "Missing encryption declaration leaves the build in Missing Compliance",
+      "severity": "high",
+      "detection": "ITSAppUsesNonExemptEncryption is not set in Info.plist, so each submission stalls in Missing Compliance and never reaches review.",
+      "signals": [],
+      "counterSignals": [
+        "ITSAppUsesNonExemptEncryption"
+      ],
+      "fix": "Set ITSAppUsesNonExemptEncryption in Info.plist. The exempt answer applies to a standard HTTPS only app."
+    },
+    {
+      "id": "APPLE-GAMBLING-BRAZIL-LICENSE",
+      "platform": "apple",
+      "guideline": "3.1.1",
+      "title": "Missing Brazilian fixed-odds betting license",
+      "severity": "critical",
+      "detection": "An app that indicates gambling/betting features but does not provide a valid fixed-odds betting license from the Secretariat of Prizes and Bets (SPA) in its App Review Information section when distributing on the Brazil storefront.",
+      "signals": [
+        "gambling",
+        "fixed-odds betting",
+        "Secretariat of Prizes and Bets",
+        "SPA license"
+      ],
+      "fix": "Select 'Yes' to the gambling question in the age rating questionnaire (which automatically sets the Brazil age rating to A18), provide a valid fixed-odds betting license from the Secretariat of Prizes and Bets (SPA) in the App Review Information field, and submit a new app version for verification."
+    },
+    {
+      "id": "APPLE-PRIVACY-MANIFEST-MISSING",
+      "platform": "apple",
+      "guideline": "Privacy Manifest",
+      "title": "Required reason APIs or third party SDKs without a privacy manifest",
+      "severity": "critical",
+      "detection": "Required reason API usage or a commonly used third party SDK is present but no PrivacyInfo.xcprivacy is bundled, or an SDK lacks its signed manifest. Enforced by Apple at upload since 2024. The top modern Apple upload rejection.",
+      "signals": [
+        "NSFileManager",
+        "UserDefaults",
+        "systemUptime",
+        "ProcessInfo",
+        "Firebase",
+        "Alamofire"
+      ],
+      "counterSignals": [
+        "PrivacyInfo.xcprivacy",
+        "NSPrivacyAccessedAPITypes"
+      ],
+      "fix": "Add a PrivacyInfo.xcprivacy with NSPrivacyAccessedAPITypes and approved reason codes, list NSPrivacyTrackingDomains, and confirm every third party SDK ships its signed manifest."
+    },
+    {
+      "id": "APPLE-PRIVACY-NUTRITION-LABELS",
+      "platform": "apple",
+      "guideline": "5.1.1",
+      "title": "Missing Privacy Nutrition Labels data type declarations",
+      "severity": "high",
+      "detection": "Collecting sensitive user data (e.g. email, phone, name, coordinates) but missing the privacyNutritionLabels declaration or proper nutrition disclosure references.",
+      "signals": [
+        "email",
+        "phoneNumber",
+        "userName",
+        "location",
+        "coordinates"
+      ],
+      "counterSignals": [
+        "NSPrivacyCollectedDataTypes",
+        "privacyNutritionLabels",
+        "privacy-nutrition-labels"
+      ],
+      "fix": "Update the app privacy manifest (PrivacyInfo.xcprivacy) with NSPrivacyCollectedDataTypes and complete corresponding Nutrition Labels in App Store Connect."
+    },
+    {
+      "id": "APPLE-RESTORE-PURCHASES-MISSING",
+      "platform": "apple",
+      "guideline": "3.1.1",
+      "title": "Non consumable purchase without a Restore Purchases control",
+      "severity": "high",
+      "detection": "StoreKit purchases are present but no restore path is found.",
+      "signals": [
+        "SKProduct",
+        "Product.purchase",
+        "StoreKit"
+      ],
+      "counterSignals": [
+        "restorePurchases",
+        "restoreCompletedTransactions",
+        "AppStore.sync",
+        "Restore Purchases"
+      ],
+      "fix": "Add a visible Restore Purchases control. It is required for non consumables and non renewing subscriptions."
+    },
+    {
+      "id": "BOTH-AI-GENERATED-CONTENT",
+      "platform": "both",
+      "guideline": "Apple 1.2, Google AI Generated Content",
+      "title": "Generative AI output without moderation or safeguards",
+      "severity": "high",
+      "detection": "A generative AI or image generation integration is present without content filtering, reporting, blocking, age rating, or abuse safeguards. Apple applies UGC rules to AI output. Google has a dedicated AI Generated Content policy.",
+      "signals": [
+        "openai",
+        "anthropic",
+        "stable diffusion",
+        "image generation",
+        "chat/completions",
+        "text-to-image"
+      ],
+      "counterSignals": [
+        "moderation",
+        "report",
+        "block user",
+        "content filter"
+      ],
+      "fix": "Add moderation, reporting, blocking, an accurate age rating, and abuse safeguards. Prevent NSFW, deepfake, face swap, and undress generation."
     },
     {
       "id": "BOTH-E-EVIDENCE-COMPLIANCE-MISSING",
@@ -1280,21 +875,19 @@
       "fix": "Designate an establishment or appoint a legal representative in the EU, notify contact details by August 18, 2026, and establish internal protocols to deliver user data securely within 8 hours in emergency situations."
     },
     {
-      "id": "BOTH-WITHDRAWAL-BUTTON-MISSING",
+      "id": "BOTH-FINGERPRINTING",
       "platform": "both",
-      "guideline": "Apple Guideline 3.1.2, Directive (EU) 2023/2673 Distance Marketing of Financial Services Directive",
-      "title": "Prominent contract withdrawal button or function missing for EU consumer contracts",
+      "guideline": "Apple 5.1.2, Google Device and Network Abuse",
+      "title": "Device fingerprinting to track users",
       "severity": "high",
-      "detection": "Apps offering digital subscriptions or distance contracts to EU consumers that fail to provide a prominent, easily accessible 'withdrawal button' or 'withdrawal function' on their online user interface to cancel/withdraw within 14 days.",
+      "detection": "Building a persistent device fingerprint from hardware or settings to identify users. Apple bans this regardless of ATT consent.",
       "signals": [
-        "withdrawal button",
-        "withdrawal function",
-        "withdraw from contract",
-        "distance contract withdrawal",
-        "revoke contract",
-        "cancel subscription"
+        "fingerprint",
+        "deviceFingerprint",
+        "canvas fingerprint",
+        "identifierForVendor cross app"
       ],
-      "fix": "Add a prominent, dedicated, and easily accessible withdrawal button or function on the user interface, allowing consumers to withdraw from contracts/subscriptions without undue friction."
+      "fix": "Do not fingerprint. Use the platform advertising identifier with consent where tracking is genuinely needed."
     },
     {
       "id": "BOTH-GPSR-COMPLIANCE-MISSING",
@@ -1319,6 +912,502 @@
         "responsiblePerson"
       ],
       "fix": "Provide prominent manufacturer contact details (email and postal address) and any applicable product safety warnings directly on the product listing or online interface for any consumer goods distributed in the EU."
+    },
+    {
+      "id": "BOTH-LOOTBOX-ODDS",
+      "platform": "both",
+      "guideline": "Apple 3.1.1, Google gambling",
+      "title": "Random reward mechanic without disclosed odds",
+      "severity": "high",
+      "detection": "Loot box, gacha, or random reward purchase present without odds disclosed before purchase.",
+      "signals": [
+        "lootbox",
+        "loot box",
+        "gacha",
+        "random reward",
+        "mystery box"
+      ],
+      "fix": "Disclose the odds for every random reward before the user purchases."
+    },
+    {
+      "id": "BOTH-METADATA-DECORATION",
+      "platform": "both",
+      "guideline": "Apple 2.3.7, Google Store Listing",
+      "title": "Metadata field overflow or banned decoration",
+      "severity": "medium",
+      "detection": "App name over the limit (Apple 30, Google 30), emoji in the title, all caps, or ranking and price claims such as number one, best, top, or free in the title or icon.",
+      "signals": [],
+      "fix": "Keep each metadata field within its limit and remove emoji, all caps, and ranking or price claims from the title and icon."
+    },
+    {
+      "id": "BOTH-SDK-SUPPLY-CHAIN",
+      "platform": "both",
+      "guideline": "SDK responsibility",
+      "title": "Third party SDK violates policy on the developer's behalf",
+      "severity": "high",
+      "detection": "A bundled SDK requests permissions, tracks users, or behaves in ways the app does not declare. The developer is responsible for SDK behavior.",
+      "signals": [],
+      "fix": "Vet every SDK, keep them current, and remove any that collect or share data the app does not declare."
+    },
+    {
+      "id": "BOTH-SECURE-STORAGE",
+      "platform": "both",
+      "guideline": "Data Security",
+      "title": "Sensitive tokens or credentials stored in insecure unencrypted formats",
+      "severity": "high",
+      "detection": "Sensitive session credentials or tokens are saved directly to unencrypted plist, UserDefaults, or SharedPreferences instead of Keychain or Android Keystore / EncryptedSharedPreferences.",
+      "signals": [
+        "UserDefaults.standard.set",
+        "getSharedPreferences"
+      ],
+      "fix": "Store all sensitive data and access tokens in iOS Keychain or Android EncryptedSharedPreferences."
+    },
+    {
+      "id": "BOTH-SUBSCRIPTION-HARD-CANCEL",
+      "platform": "both",
+      "guideline": "Apple 3.1.2 subscription terms, US FTC Section 5 / ROSCA, state subscription-cancellation statutes (California, New York, Massachusetts)",
+      "title": "Subscription cancellation requires a phone call, mail, or in-person visit while sign-up is a single tap",
+      "severity": "high",
+      "detection": "A subscription billed outside Apple in-app purchase or Google Play Billing (a web or account-settings cancellation path) directs the person to call, mail, or visit in person to cancel, instead of a self-service in-app or web cancel action. The federal FTC click-to-cancel rule was vacated in 2025 but California, New York, and Massachusetts have their own negative-option statutes in force, and the FTC retains Section 5 and ROSCA authority regardless.",
+      "signals": [
+        "call us to cancel",
+        "call to cancel",
+        "cancel your subscription by calling",
+        "mail a letter to cancel",
+        "write to cancel",
+        "cancel in person",
+        "visit a store to cancel"
+      ],
+      "fix": "Provide a self-service cancellation path (in-app button or account-settings web page) that is at least as easy as sign-up. Never require a phone call, a mailed letter, or an in-person visit to cancel a subscription billed outside the app stores' own billing."
+    },
+    {
+      "id": "BOTH-UNREACHABLE-METADATA-URL",
+      "platform": "both",
+      "guideline": "Apple 1.5 and 2.1, Google User Data",
+      "title": "Broken support, marketing, or privacy URL in the listing",
+      "severity": "high",
+      "detection": "A support URL, marketing URL, or privacy policy URL in the listing does not load. Mirrors the fastlane precheck unreachable_urls rule.",
+      "signals": [],
+      "fix": "Confirm every listing URL is public and loads during the entire review window."
+    },
+    {
+      "id": "BOTH-UNSAFE-DEEPLINK",
+      "platform": "both",
+      "guideline": "Data Security",
+      "title": "Unsafe or unvalidated custom deep link URL schemes used for sensitive operations",
+      "severity": "high",
+      "detection": "Relying on custom URL schemes for sensitive routing, navigation, or passing tokens, without strict input validation.",
+      "signals": [
+        "CFBundleURLSchemes",
+        "android:scheme"
+      ],
+      "counterSignals": [
+        "apple-app-site-association",
+        "assetlinks.json"
+      ],
+      "fix": "Use Universal Links (iOS) and App Links (Android) for secure domain-validated link routing, and sanitize all deep link parameters."
+    },
+    {
+      "id": "BOTH-WITHDRAWAL-BUTTON-MISSING",
+      "platform": "both",
+      "guideline": "Apple Guideline 3.1.2, Directive (EU) 2023/2673 Distance Marketing of Financial Services Directive",
+      "title": "Prominent contract withdrawal button or function missing for EU consumer contracts",
+      "severity": "high",
+      "detection": "Apps offering digital subscriptions or distance contracts to EU consumers that fail to provide a prominent, easily accessible 'withdrawal button' or 'withdrawal function' on their online user interface to cancel/withdraw within 14 days.",
+      "signals": [
+        "withdrawal button",
+        "withdrawal function",
+        "withdraw from contract",
+        "distance contract withdrawal",
+        "revoke contract",
+        "cancel subscription"
+      ],
+      "fix": "Add a prominent, dedicated, and easily accessible withdrawal button or function on the user interface, allowing consumers to withdraw from contracts/subscriptions without undue friction."
+    },
+    {
+      "id": "CHINA-AI-REFERENCES",
+      "platform": "apple",
+      "guideline": "5",
+      "title": "External AI service references in a China storefront",
+      "severity": "high",
+      "detection": "Manual storefront check. References to ChatGPT, Gemini, OpenAI, or similar external AI services in an app distributed on the China storefront can trigger a regional rejection.",
+      "signals": [],
+      "fix": "Remove or localize external AI service references for the China storefront. Source. truongduy2611 china_storefront rule."
+    },
+    {
+      "id": "FLUTTER-PRIVACY-MANIFEST-MISSING",
+      "platform": "apple",
+      "guideline": "5.1.1",
+      "framework": "flutter",
+      "title": "Flutter plugin touches required-reason APIs with no PrivacyInfo.xcprivacy",
+      "severity": "critical",
+      "detection": "pubspec.yaml present, a plugin known to touch required-reason APIs (permission_handler, image_picker, geolocator, device_info_plus, package_info_plus, shared_preferences, sqflite, firebase_*) is a dependency, and no PrivacyInfo.xcprivacy exists anywhere in the project.",
+      "signals": [
+        "pubspec.yaml",
+        "permission_handler",
+        "image_picker",
+        "firebase_"
+      ],
+      "fix": "Add an app-level PrivacyInfo.xcprivacy and confirm each Flutter plugin ships its own (Flutter 3.19+ plugins mostly do). A missing plugin-level manifest is invisible to Apple unless the app manifest also declares that plugin reason code."
+    },
+    {
+      "id": "GOOGLE-12-TESTER-RULE",
+      "platform": "google",
+      "guideline": "Closed testing requirement",
+      "title": "New personal account without the closed test",
+      "severity": "high",
+      "detection": "Manual check. New personal developer accounts need at least 12 testers for 14 consecutive days of closed testing before production.",
+      "signals": [],
+      "fix": "Run the closed test with at least 12 testers over 14 consecutive days, or use an organization account where appropriate."
+    },
+    {
+      "id": "GOOGLE-DATASAFETY-MISMATCH",
+      "platform": "google",
+      "guideline": "Data Safety",
+      "title": "Data Safety form does not match runtime behavior",
+      "severity": "critical",
+      "detection": "Analytics, ads, or tracking SDKs are present that collect or share data not declared in the Data Safety section. This is the number one Google rejection cause.",
+      "signals": [
+        "firebase-analytics",
+        "com.google.android.gms.ads",
+        "facebook",
+        "appsflyer",
+        "adjust"
+      ],
+      "fix": "Audit every SDK and runtime data flow and declare every collection, sharing, and security practice accurately in the Data Safety form."
+    },
+    {
+      "id": "GOOGLE-FAMILIES-AD-SDK",
+      "platform": "google",
+      "guideline": "Families",
+      "title": "Non compliant ad SDK in a child targeted app",
+      "severity": "critical",
+      "detection": "An app declared for children uses an ad SDK that is not Families certified, or shows behavioral ads to minors.",
+      "signals": [
+        "children",
+        "Designed for Families",
+        "kids"
+      ],
+      "fix": "Use only Families certified ad SDKs and remove behavioral advertising to minors."
+    },
+    {
+      "id": "GOOGLE-MISLEADING-LISTING",
+      "platform": "google",
+      "guideline": "Store Listing and Promotion",
+      "title": "Listing claims a feature the app lacks",
+      "severity": "high",
+      "detection": "Manual check. The store listing, screenshots, and description must match the app's actual functionality.",
+      "signals": [],
+      "fix": "Make the listing match the build exactly, with screenshots of real in app screens."
+    },
+    {
+      "id": "GOOGLE-MISSING-PRIVACY-POLICY",
+      "platform": "google",
+      "guideline": "User Data",
+      "title": "Missing privacy policy",
+      "severity": "critical",
+      "detection": "No privacy policy URL set in the Play Console store listing while the app collects user data.",
+      "signals": [
+        "privacyPolicy",
+        "privacy-policy"
+      ],
+      "fix": "Publish a privacy policy and set its URL in the Play Console store listing."
+    },
+    {
+      "id": "GOOGLE-PERM-ACCESSIBILITY-MISUSE",
+      "platform": "google",
+      "guideline": "Permissions and APIs",
+      "title": "AccessibilityService used for non accessibility purposes",
+      "severity": "critical",
+      "detection": "BIND_ACCESSIBILITY_SERVICE declared in an app that is not an accessibility tool.",
+      "signals": [
+        "BIND_ACCESSIBILITY_SERVICE",
+        "AccessibilityService"
+      ],
+      "fix": "Use accessibility APIs only for genuine accessibility features and declare the use, or remove the service."
+    },
+    {
+      "id": "GOOGLE-PERM-ALL-FILES",
+      "platform": "google",
+      "guideline": "Permissions and APIs",
+      "title": "All files access without a qualifying use case",
+      "severity": "critical",
+      "detection": "MANAGE_EXTERNAL_STORAGE declared in AndroidManifest.",
+      "signals": [
+        "MANAGE_EXTERNAL_STORAGE"
+      ],
+      "fix": "Use scoped storage. Request all files access only for a qualifying use case with the required declaration."
+    },
+    {
+      "id": "GOOGLE-PERM-BACKGROUND-LOCATION",
+      "platform": "google",
+      "guideline": "Permissions and APIs",
+      "title": "Background location without a qualifying core feature",
+      "severity": "critical",
+      "detection": "ACCESS_BACKGROUND_LOCATION declared in AndroidManifest with no clear core feature or prominent disclosure.",
+      "signals": [
+        "ACCESS_BACKGROUND_LOCATION"
+      ],
+      "fix": "Use foreground location where possible, or justify background use with a core feature and a prominent disclosure and the permission declaration."
+    },
+    {
+      "id": "GOOGLE-PERM-SMS-CALLLOG",
+      "platform": "google",
+      "guideline": "Permissions and APIs",
+      "title": "SMS or Call Log without an approved core use case",
+      "severity": "critical",
+      "detection": "READ_SMS, SEND_SMS, RECEIVE_SMS, READ_CALL_LOG, or WRITE_CALL_LOG declared without an approved use case.",
+      "signals": [
+        "READ_SMS",
+        "SEND_SMS",
+        "RECEIVE_SMS",
+        "READ_CALL_LOG",
+        "WRITE_CALL_LOG"
+      ],
+      "fix": "Use the permissions declaration form for an approved core use case, or drop the permission."
+    },
+    {
+      "id": "GOOGLE-PLAY-AGE-SIGNALS-MISUSE",
+      "platform": "google",
+      "guideline": "User Data",
+      "title": "Misuse of Play Age Signals API",
+      "severity": "critical",
+      "detection": "Usage of the Play Age Signals API (com.google.android.play:age-signals) in conjunction with advertising, marketing, user profiling, or analytics libraries, which violates Google Play's strict Terms of Service.",
+      "signals": [
+        "com.google.android.play:age-signals",
+        "AgeSignalsManager",
+        "AgeSignalsRequest"
+      ],
+      "fix": "Ensure that information from the Play Age Signals API is solely used to provide age-appropriate content and experiences in compliance with laws. Do not use the API or its returned signals for advertising, marketing, user profiling, or analytics."
+    },
+    {
+      "id": "GOOGLE-PLAY-BILLING",
+      "platform": "google",
+      "guideline": "Payments",
+      "title": "Digital goods sold without Play Billing",
+      "severity": "critical",
+      "detection": "A web checkout or third party payment SDK is used for in app digital goods rather than Play Billing.",
+      "signals": [
+        "Stripe",
+        "PayPal",
+        "checkout",
+        "razorpay"
+      ],
+      "counterSignals": [
+        "BillingClient",
+        "Play Billing",
+        "com.android.billingclient"
+      ],
+      "fix": "Use Play Billing for in app digital goods, with regional alternatives only where Google permits."
+    },
+    {
+      "id": "GOOGLE-TARGET-API",
+      "platform": "google",
+      "guideline": "Target API level",
+      "title": "App does not target the current required API level",
+      "severity": "high",
+      "detection": "targetSdkVersion in build.gradle is below the current Google Play requirement. From 31 August 2026, new apps and updates must target Android 16, API level 36, or higher.",
+      "signals": [
+        "targetSdkVersion",
+        "targetSdk"
+      ],
+      "fix": "Build against the current required Android target API level. From 31 August 2026 that is API 36 or higher. Submissions below the threshold are rejected automatically."
+    },
+    {
+      "id": "IONIC-4.2-THIN-WRAPPER",
+      "platform": "apple",
+      "guideline": "4.2",
+      "framework": "ionic-capacitor",
+      "title": "Thin WebView wrapper with insufficient native functionality",
+      "severity": "critical",
+      "detection": "A Capacitor/Cordova/WKWebView marker is present alongside fewer than 2 distinct native-feel plugins (status bar, splash screen, push notifications, haptics, share, camera, local notifications).",
+      "signals": [
+        "WKWebView",
+        "Capacitor",
+        "Cordova"
+      ],
+      "fix": "Apple 4.2 Minimum Functionality is the single most common Ionic rejection. Add native Capacitor/Cordova plugins for status bar, splash transition, push, and haptics, or ship as an installable PWA to skip App Review."
+    },
+    {
+      "id": "IONIC-PRIVACY-MANIFEST-MISSING",
+      "platform": "apple",
+      "guideline": "5.1.1",
+      "framework": "ionic-capacitor",
+      "title": "Capacitor/Cordova plugin wrapping a native SDK with no PrivacyInfo.xcprivacy",
+      "severity": "high",
+      "detection": "Capacitor/Cordova plugins are present and no PrivacyInfo.xcprivacy exists anywhere in the project.",
+      "signals": [
+        "@capacitor/",
+        "Capacitor."
+      ],
+      "fix": "Capacitor plugin manifest support is less standardized than Flutter's. Verify each plugin wrapping a native SDK (camera, geolocation, ads) ships PrivacyInfo.xcprivacy, and add the app-level one."
+    },
+    {
+      "id": "IONIC-UIWEBVIEW-DEPRECATED",
+      "platform": "apple",
+      "guideline": "2.5.1",
+      "framework": "ionic-capacitor",
+      "title": "Deprecated UIWebView symbol statically linked",
+      "severity": "critical",
+      "detection": "The literal UIWebView symbol appears anywhere in the built sources, often pulled in transitively by a stale Capacitor or Cordova plugin.",
+      "signals": [
+        "UIWebView"
+      ],
+      "fix": "Apple auto-rejects (ITMS-90809) any binary statically linking UIWebView. Update every plugin to a WKWebView-based version."
+    },
+    {
+      "id": "RN-OTA-UNDECLARED",
+      "platform": "apple",
+      "guideline": "3.3.2",
+      "framework": "react-native",
+      "title": "Undisclosed over-the-air JS bundle updater",
+      "severity": "high",
+      "detection": "package.json depends on react-native or expo, and an OTA updater (react-native-code-push, expo-updates, react-native-ota-hot-update, Stallion) is present with no App Review disclosure of bug-fix-only scope.",
+      "signals": [
+        "react-native-code-push",
+        "CodePush.",
+        "expo-updates",
+        "Stallion"
+      ],
+      "fix": "Name the OTA mechanism in App Review notes and restrict it to bug fixes that do not change purpose, UI, or features beyond what was reviewed (Apple 3.3.2, 2.5.2)."
+    },
+    {
+      "id": "RN-PRIVACY-MANIFEST-MISSING",
+      "platform": "apple",
+      "guideline": "5.1.1",
+      "framework": "react-native",
+      "title": "React Native native module touches required-reason APIs with no PrivacyInfo.xcprivacy",
+      "severity": "critical",
+      "detection": "package.json depends on react-native or expo, native modules with required-reason API usage are present (Firebase, AsyncStorage, expo-file-system), and no PrivacyInfo.xcprivacy exists.",
+      "signals": [
+        "@react-native-firebase",
+        "AsyncStorage",
+        "expo-file-system"
+      ],
+      "fix": "Add an app-level PrivacyInfo.xcprivacy. Native modules bundled transitively via JS deps each need their own manifest aggregated in the final IPA."
+    },
+    {
+      "id": "WEB-COOKIE-CONSENT",
+      "platform": "web",
+      "guideline": "ePrivacy Directive",
+      "title": "Setting non-essential cookies without prior cookie consent",
+      "severity": "critical",
+      "detection": "Writing to document.cookie or cookieStore without checking if the user accepted cookies via a cookie consent banner.",
+      "signals": [
+        "document.cookie",
+        "setCookie",
+        "cookieStore",
+        "js-cookie",
+        "cookieConsent"
+      ],
+      "counterSignals": [
+        "cookieBanner",
+        "cookieConsentBanner",
+        "acceptCookies",
+        "cookiePreferences"
+      ],
+      "fix": "Implement a compliant Cookie Consent banner that blocks non-essential cookies until the user gives explicit consent."
+    },
+    {
+      "id": "WEB-GDPR-COMPLIANCE",
+      "platform": "web",
+      "guideline": "GDPR",
+      "title": "Processing web personal data without GDPR compliance controls",
+      "severity": "critical",
+      "detection": "Collecting or processing personal web data without explicit opt-in controls, privacy policy links, or right to be forgotten (delete) options.",
+      "signals": [
+        "processData",
+        "personalData",
+        "submitForm",
+        "registerWeb",
+        "webForm"
+      ],
+      "counterSignals": [
+        "GDPR",
+        "opt-in",
+        "privacyConsent",
+        "deletePersonalData",
+        "exportData"
+      ],
+      "fix": "Integrate standard GDPR compliance gates including explicit opt-in for data processing and a mechanism for data deletion."
+    },
+    {
+      "id": "WEB-INDEXEDDB",
+      "platform": "web",
+      "guideline": "GDPR",
+      "title": "Structured personal data stored in IndexedDB without security controls",
+      "severity": "high",
+      "detection": "Storing user records in IndexedDB without user consent, encryption, or proper deletion lifecycles.",
+      "signals": [
+        "indexedDB.open",
+        "indexedDB",
+        "createObjectStore"
+      ],
+      "counterSignals": [
+        "encryptDatabase",
+        "deleteDatabase",
+        "consentIndexedDB"
+      ],
+      "fix": "Use encrypted IndexedDB wrappers for structured sensitive records, check user consent, and clear databases upon logout."
+    },
+    {
+      "id": "WEB-LOCAL-STORAGE",
+      "platform": "web",
+      "guideline": "GDPR",
+      "title": "Unencrypted sensitive personal data stored in localStorage",
+      "severity": "high",
+      "detection": "Storing sensitive details or JWT tokens in plain text in localStorage without encryption or user consent check.",
+      "signals": [
+        "localStorage.setItem",
+        "localStorage"
+      ],
+      "counterSignals": [
+        "encryptedStorage",
+        "encryptToken",
+        "consentLocalStorage",
+        "clearLocalStorage"
+      ],
+      "fix": "Avoid storing plain sensitive personal info in localStorage, encrypt any stored tokens, and respect storage preferences."
+    },
+    {
+      "id": "WEB-SESSION-STORAGE",
+      "platform": "web",
+      "guideline": "GDPR",
+      "title": "Sensitive session details stored in sessionStorage without protection",
+      "severity": "high",
+      "detection": "Storing raw authentication or session keys in sessionStorage without encryption or clean-up logic.",
+      "signals": [
+        "sessionStorage.setItem",
+        "sessionStorage"
+      ],
+      "counterSignals": [
+        "encryptedSession",
+        "clearSessionStorage"
+      ],
+      "fix": "Limit and secure the data written to sessionStorage, apply encryption, and ensure data is deleted at session end."
+    },
+    {
+      "id": "WEB-TRACKING-TECHNOLOGIES",
+      "platform": "web",
+      "guideline": "GDPR",
+      "title": "Third-party tracking technologies loaded without consent",
+      "severity": "high",
+      "detection": "Integrating analytic pixels or tracking scripts (Google Analytics, Facebook Pixel, Hotjar) without consent validation.",
+      "signals": [
+        "gtag",
+        "fbq",
+        "google-analytics",
+        "trackingPixel",
+        "analytics.js",
+        "hotjar"
+      ],
+      "counterSignals": [
+        "consentTracking",
+        "disableTracking",
+        "optOutTracking",
+        "trackingPreferences"
+      ],
+      "fix": "Load third-party tracking scripts and pixels conditionally only after receiving explicit user cookie consent."
     }
   ]
 }

--- a/data/rejection-patterns.json
+++ b/data/rejection-patterns.json
@@ -1219,8 +1219,8 @@
       "guideline": "4.2",
       "framework": "ionic-capacitor",
       "title": "Thin WebView wrapper with insufficient native functionality",
-      "severity": "critical",
-      "detection": "A Capacitor/Cordova/WKWebView marker is present alongside fewer than 2 distinct native-feel plugins (status bar, splash screen, push notifications, haptics, share, camera, local notifications).",
+      "severity": "high",
+      "detection": "A Capacitor/Cordova/WKWebView marker is present alongside fewer than 2 distinct native-feel plugins (status bar, splash screen, push notifications, haptics, share, camera, local notifications). This is a heuristic proxy for the real Apple 4.2 test (features/content/UI beyond a repackaged website), reviewed manually before treating as a blocker.",
       "signals": [
         "WKWebView",
         "Capacitor",

--- a/docs/CROSS-PLATFORM-FRAMEWORKS.md
+++ b/docs/CROSS-PLATFORM-FRAMEWORKS.md
@@ -14,7 +14,16 @@ generated the app, on top of the native checks.
 | Ionic / Capacitor / Cordova | `package.json` dependency on `@capacitor/*`, `@ionic/*`, or `cordova-*`, OR a `capacitor.config.*` / `config.xml` file |
 
 A project can match more than one framework flag (a Capacitor app that also
-imports `expo` polyfills, for example); every matching check runs.
+imports `expo` polyfills, for example); every matching check runs. Detection scans
+EVERY `package.json`/`config.xml` within depth, not only the first, so a monorepo
+whose root `package.json` is tooling-only still finds the real app deeper in the
+tree. A `config.xml` only counts as Cordova evidence when it carries a `<widget>`
+or `xmlns:cdv` marker, since that filename collides with unrelated tooling configs.
+
+Every framework-specific finding below is gated on `IS_IOS` (an `Info.plist` or
+Xcode project detected). All of it is Apple-specific policy (Guideline 4.2,
+3.3.2, the PrivacyInfo.xcprivacy requirement), so an Android-only build such as
+`flutter build appbundle` or `flutter build apk` never trips these checks.
 
 ## Submission commands the guard recognizes
 
@@ -56,19 +65,48 @@ before submitting.
 
 ## Ionic / Capacitor / Cordova checks
 
-- `IONIC-4.2-THIN-WRAPPER` (critical). The single most common Ionic rejection.
-  A WebView/Capacitor/Cordova marker is present with fewer than 2 DISTINCT
-  native-feel plugins (status bar, splash screen, push notifications, haptics,
-  share, camera, local notifications). Counts distinct plugin identifiers, not
-  files, so multiple plugin imports in one bootstrap file are counted correctly.
-  Fix by adding native chrome plugins, or ship as an installable PWA to skip App
-  Review entirely.
+- `IONIC-4.2-THIN-WRAPPER` (high, advisory). The single most common Ionic
+  rejection reason in the wild, but this check is a HEURISTIC PROXY, not the
+  actual Apple 4.2 test, which is about features, content, and UI beyond a
+  repackaged website, not a plugin count. A real app using unmatched plugins
+  (`@capacitor/preferences`, private native plugins) can false-positive; a thin
+  wrapper that imports two matched plugins for cosmetic reasons can false-negative.
+  Review manually before treating this as a hard blocker. Counts distinct plugin
+  identifiers, not files, so multiple plugin imports in one bootstrap file are
+  counted correctly.
 - `IONIC-UIWEBVIEW-DEPRECATED` (critical). The literal `UIWebView` symbol,
   usually pulled in by a stale plugin even when app code never references it
   directly. Apple auto-rejects (ITMS-90809) any binary that statically links it.
 - `IONIC-PRIVACY-MANIFEST-MISSING` (high). Capacitor/Cordova plugin manifest
   support is less standardized than Flutter's. Verify each plugin wrapping a
   native SDK ships its own `PrivacyInfo.xcprivacy`.
+
+## Known gaps (found by a Codex adversarial review, not yet fixed)
+
+- **Android-side framework checks are absent.** Every check in this doc is
+  Apple-side. Flutter/RN/Ionic apps also ship to Google Play, where Data Safety
+  disclosure for bundled SDKs, WebView-controlled data collection, cleartext
+  traffic, and mixed-content/debug flags are real, framework-relevant risks this
+  guard does not yet check.
+- **The PrivacyInfo.xcprivacy presence check is both too loose and too strict.**
+  It accepts a manifest found anywhere, including inside `node_modules` or
+  `Pods`, which does not prove an APP-LEVEL manifest exists. It also has no
+  Expo-managed-workflow awareness (`expo.ios.privacyManifests` in `app.json`
+  can be valid with no `ios/PrivacyInfo.xcprivacy` on disk yet, since EAS
+  generates the native project remotely at build time).
+- **Expo Continuous Native Generation (CNG) is not modeled.** A managed Expo
+  project legitimately has no committed `ios/`/`android/` folder; treating that
+  as "no iOS target" is not always correct.
+- **Other cross-platform frameworks have no coverage.** NativeScript,
+  Xamarin/.NET MAUI, Kotlin Multiplatform, Unity (mobile export), and Tauri
+  Mobile are not detected at all.
+- **The submission regex still misses a few real commands**
+  (`eas build` with no platform flag, ambiguous local `cap run` without a
+  release intent) and can overfire on non-release local dev commands.
+
+These are logged, not hidden. Track them before treating this guard as complete
+coverage for a cross-platform team; the checks that exist are a real
+improvement over native-only, not a finished answer.
 
 ## The honest limit
 

--- a/docs/CROSS-PLATFORM-FRAMEWORKS.md
+++ b/docs/CROSS-PLATFORM-FRAMEWORKS.md
@@ -20,10 +20,16 @@ whose root `package.json` is tooling-only still finds the real app deeper in the
 tree. A `config.xml` only counts as Cordova evidence when it carries a `<widget>`
 or `xmlns:cdv` marker, since that filename collides with unrelated tooling configs.
 
-Every framework-specific finding below is gated on `IS_IOS` (an `Info.plist` or
-Xcode project detected). All of it is Apple-specific policy (Guideline 4.2,
-3.3.2, the PrivacyInfo.xcprivacy requirement), so an Android-only build such as
-`flutter build appbundle` or `flutter build apk` never trips these checks.
+Every framework-specific finding below is gated on `IOS_TARGET_ACTIVE`, not raw
+file-tree presence. A committed `ios/` folder is common in a real cross-platform
+repo even when the current build is Android-only, so file presence alone cannot
+tell `flutter build apk` apart from an iOS build. When the invoking command is
+known (hook mode) and clearly targets Android only (`build apk/appbundle`,
+`assembleRelease`, `bundleRelease`, `run-android`, `run:android`,
+`--platform android`, `capacitor android`, with no `ios`/`ipa`/`xcodebuild`
+token present), the command overrides the file-tree signal and these Apple-only
+checks stay silent. Standalone mode (no command context) falls back to plain
+file-tree detection.
 
 ## Submission commands the guard recognizes
 
@@ -81,8 +87,16 @@ before submitting.
   support is less standardized than Flutter's. Verify each plugin wrapping a
   native SDK ships its own `PrivacyInfo.xcprivacy`.
 
-## Known gaps (found by a Codex adversarial review, not yet fixed)
+## Known gaps (found by Codex and Qwen adversarial review, not yet fixed)
 
+- **Newline-containing file paths.** The `package.json`/`config.xml` scan loops
+  are safe against spaces and shell metacharacters (quoted `IFS= read -r`), but
+  not against a literal newline inside a path, which `find`'s newline-delimited
+  output cannot represent. Extremely unlikely in practice, and not proven safe.
+- **`config.xml` widget-marker check is spoofable by a comment.** A commented-out
+  `<!-- <widget ...> -->` or a look-alike tag like `<widgetConfig>` still counts
+  as Cordova evidence. Low severity, no realistic false negative on a real
+  Cordova project, though not a hard proof either.
 - **Android-side framework checks are absent.** Every check in this doc is
   Apple-side. Flutter/RN/Ionic apps also ship to Google Play, where Data Safety
   disclosure for bundled SDKs, WebView-controlled data collection, cleartext

--- a/docs/CROSS-PLATFORM-FRAMEWORKS.md
+++ b/docs/CROSS-PLATFORM-FRAMEWORKS.md
@@ -1,0 +1,79 @@
+# Cross-Platform Framework Coverage
+
+The guard scans the app's built artifact surface (Info.plist, AndroidManifest.xml,
+entitlements, gradle, PrivacyInfo.xcprivacy) which store review inspects regardless of
+what generated it. This page documents the checks specific to the framework that
+generated the app, on top of the native checks.
+
+## Detection
+
+| Framework | Detected by |
+|---|---|
+| Flutter | `pubspec.yaml` present within 3 levels of the project root |
+| React Native / Expo | `package.json` dependency on `react-native` or `expo` |
+| Ionic / Capacitor / Cordova | `package.json` dependency on `@capacitor/*`, `@ionic/*`, or `cordova-*`, OR a `capacitor.config.*` / `config.xml` file |
+
+A project can match more than one framework flag (a Capacitor app that also
+imports `expo` polyfills, for example); every matching check runs.
+
+## Submission commands the guard recognizes
+
+`fastlane deliver/pilot/supply/submit`, `eas submit`, `eas build`, `xcrun altool`,
+`xcrun notarytool`, `transporter`, `gradlew bundleRelease/assembleRelease`,
+`bundletool`, `xcodebuild archive`, `flutter build ipa/appbundle/apk`,
+`cap sync/build/run` (with or without `npx`), `ionic capacitor build/run`,
+`cordova build` (with or without `--release`).
+
+## Flutter checks
+
+- `FLUTTER-PRIVACY-MANIFEST-MISSING` (critical). A required-reason-API plugin
+  (permission_handler, image_picker, geolocator, device_info_plus,
+  package_info_plus, shared_preferences, sqflite, firebase_*) is a dependency and
+  no `PrivacyInfo.xcprivacy` exists anywhere in the project. Since Flutter 3.19
+  most first-party plugins ship their own manifest, but the aggregation only
+  works when the app also ships one.
+- `FLUTTER-NO-IOS-RUNNER-FOUND` (medium, advisory). No `Info.plist` was found, so
+  every iOS-specific check in this guard was skipped. Run `flutter create .` or
+  confirm the `ios/` platform folder exists before an iOS submission.
+
+Known limitation. The guard cannot see whether a purpose-string value that
+exists only in a localized `InfoPlist.strings` file was also copied into the
+real `Info.plist` shipped in the archive (ITMS-90683). Check this by hand
+before submitting.
+
+## React Native / Expo checks
+
+- `RN-OTA-UNDECLARED` (high). An over-the-air JS bundle updater
+  (`react-native-code-push`, `expo-updates`, `react-native-ota-hot-update`,
+  Stallion) is present with no App Review disclosure. Apple 3.3.2/2.5.2 allow
+  bug-fix-only OTA updates when disclosed by name in the review notes; an
+  undeclared swappable bundle reads as dormant functionality.
+- `RN-PRIVACY-MANIFEST-MISSING` (critical). A native module touching
+  required-reason APIs (Firebase, AsyncStorage, expo-file-system) is present
+  transitively via a JS dependency and no `PrivacyInfo.xcprivacy` exists. This is
+  the hardest of the three frameworks to audit by eye because the native SDK
+  hides behind a JS package name.
+
+## Ionic / Capacitor / Cordova checks
+
+- `IONIC-4.2-THIN-WRAPPER` (critical). The single most common Ionic rejection.
+  A WebView/Capacitor/Cordova marker is present with fewer than 2 DISTINCT
+  native-feel plugins (status bar, splash screen, push notifications, haptics,
+  share, camera, local notifications). Counts distinct plugin identifiers, not
+  files, so multiple plugin imports in one bootstrap file are counted correctly.
+  Fix by adding native chrome plugins, or ship as an installable PWA to skip App
+  Review entirely.
+- `IONIC-UIWEBVIEW-DEPRECATED` (critical). The literal `UIWebView` symbol,
+  usually pulled in by a stale plugin even when app code never references it
+  directly. Apple auto-rejects (ITMS-90809) any binary that statically links it.
+- `IONIC-PRIVACY-MANIFEST-MISSING` (high). Capacitor/Cordova plugin manifest
+  support is less standardized than Flutter's. Verify each plugin wrapping a
+  native SDK ships its own `PrivacyInfo.xcprivacy`.
+
+## The honest limit
+
+The guard reads Swift, Kotlin, XML, Gradle, Plist, Dart, JS, and TS source text.
+It does not execute the app, does not parse the Dart or JS AST, and cannot see
+runtime behavior (whether an OTA update actually changes the UI, for example).
+Treat every finding as a lead to verify, not a guaranteed defect, and treat a
+clean run as "nothing detectable from source text", not a guarantee of approval.

--- a/references/README.md
+++ b/references/README.md
@@ -5,10 +5,10 @@ A structured, AI loadable reference tree. Load the rule category and the app typ
 ## Rules by category
 
 - [rules/metadata.md](rules/metadata.md). Metadata and store listing. 9 rules
-- [rules/privacy.md](rules/privacy.md). Privacy and data. 14 rules
+- [rules/privacy.md](rules/privacy.md). Privacy and data. 17 rules
 - [rules/payments.md](rules/payments.md). Payments, in app purchase, subscriptions. 8 rules
-- [rules/design.md](rules/design.md). Design and login. 3 rules
-- [rules/performance.md](rules/performance.md). Performance and completeness. 22 rules
+- [rules/design.md](rules/design.md). Design and login. 4 rules
+- [rules/performance.md](rules/performance.md). Performance and completeness. 24 rules
 - [rules/entitlements.md](rules/entitlements.md). Entitlements. 1 rules
 - [rules/safety.md](rules/safety.md). Safety and user generated content. 3 rules
 - [rules/android.md](rules/android.md). Google Play specific. 22 rules

--- a/references/rules/android.md
+++ b/references/rules/android.md
@@ -2,116 +2,21 @@
 
 22 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
 
-## GOOGLE-DATASAFETY-MISMATCH
+## ANDROID-HEALTH-PERMISSIONS
 
-- Title. Data Safety form does not match runtime behavior
-- Platform. google
-- Guideline or policy. Data Safety
-- Severity. critical
-- What triggers it. Analytics, ads, or tracking SDKs are present that collect or share data not declared in the Data Safety section. This is the number one Google rejection cause.
-- How to fix it. Audit every SDK and runtime data flow and declare every collection, sharing, and security practice accurately in the Data Safety form.
-- Detection signals. firebase-analytics, com.google.android.gms.ads, facebook, appsflyer, adjust
-
-How to detect.
-
-```bash
-grep -rn 'firebase-analytics\|com.google.android.gms.ads\|appsflyer\|adjust\|com.facebook' --include='*.gradle' --include='*.kts' .   # every SDK that collects or shares data must be declared in Data Safety
-```
-
-## GOOGLE-PERM-BACKGROUND-LOCATION
-
-- Title. Background location without a qualifying core feature
+- Title. Health or fitness data access without Health Connect declaration
 - Platform. google
 - Guideline or policy. Permissions and APIs
 - Severity. critical
-- What triggers it. ACCESS_BACKGROUND_LOCATION declared in AndroidManifest with no clear core feature or prominent disclosure.
-- How to fix it. Use foreground location where possible, or justify background use with a core feature and a prominent disclosure and the permission declaration.
-- Detection signals. ACCESS_BACKGROUND_LOCATION
+- What triggers it. Accessing Health Connect client or querying health permissions (e.g. steps, heart rate) without proper declaration or dedicated health privacy policy.
+- How to fix it. Declare Health Connect permissions, complete the console Health Connect form, and maintain a dedicated health privacy policy.
+- Detection signals. HealthConnectClient, com.google.android.gms.permission.HealthConnect, READ_STEPS, READ_HEART_RATE
+- Present means handled. healthConnectConsent, healthPrivacyPolicy, Health Connect
 
 How to detect.
 
 ```bash
-grep -rn 'ACCESS_BACKGROUND_LOCATION' --include='AndroidManifest.xml' .
-```
-
-## GOOGLE-PERM-ALL-FILES
-
-- Title. All files access without a qualifying use case
-- Platform. google
-- Guideline or policy. Permissions and APIs
-- Severity. critical
-- What triggers it. MANAGE_EXTERNAL_STORAGE declared in AndroidManifest.
-- How to fix it. Use scoped storage. Request all files access only for a qualifying use case with the required declaration.
-- Detection signals. MANAGE_EXTERNAL_STORAGE
-
-How to detect.
-
-```bash
-grep -rn 'MANAGE_EXTERNAL_STORAGE' --include='AndroidManifest.xml' .
-```
-
-## GOOGLE-PERM-SMS-CALLLOG
-
-- Title. SMS or Call Log without an approved core use case
-- Platform. google
-- Guideline or policy. Permissions and APIs
-- Severity. critical
-- What triggers it. READ_SMS, SEND_SMS, RECEIVE_SMS, READ_CALL_LOG, or WRITE_CALL_LOG declared without an approved use case.
-- How to fix it. Use the permissions declaration form for an approved core use case, or drop the permission.
-- Detection signals. READ_SMS, SEND_SMS, RECEIVE_SMS, READ_CALL_LOG, WRITE_CALL_LOG
-
-How to detect.
-
-```bash
-grep -rnE 'permission.(READ_SMS|SEND_SMS|RECEIVE_SMS|READ_CALL_LOG|WRITE_CALL_LOG)' --include='AndroidManifest.xml' .
-```
-
-## GOOGLE-PERM-ACCESSIBILITY-MISUSE
-
-- Title. AccessibilityService used for non accessibility purposes
-- Platform. google
-- Guideline or policy. Permissions and APIs
-- Severity. critical
-- What triggers it. BIND_ACCESSIBILITY_SERVICE declared in an app that is not an accessibility tool.
-- How to fix it. Use accessibility APIs only for genuine accessibility features and declare the use, or remove the service.
-- Detection signals. BIND_ACCESSIBILITY_SERVICE, AccessibilityService
-
-How to detect.
-
-```bash
-grep -rn 'BIND_ACCESSIBILITY_SERVICE\|AccessibilityService' --include='AndroidManifest.xml' --include='*.kt' --include='*.java' .
-```
-
-## GOOGLE-FAMILIES-AD-SDK
-
-- Title. Non compliant ad SDK in a child targeted app
-- Platform. google
-- Guideline or policy. Families
-- Severity. critical
-- What triggers it. An app declared for children uses an ad SDK that is not Families certified, or shows behavioral ads to minors.
-- How to fix it. Use only Families certified ad SDKs and remove behavioral advertising to minors.
-- Detection signals. children, Designed for Families, kids
-
-How to detect.
-
-```bash
-grep -rn 'com.google.android.gms.ads\|applovin\|unity.*ads\|ironsource' --include='*.gradle' . && grep -rni 'children\|families\|kids' --include='AndroidManifest.xml' .
-```
-
-## GOOGLE-PLAY-AGE-SIGNALS-MISUSE
-
-- Title. Misuse of Play Age Signals API
-- Platform. google
-- Guideline or policy. User Data
-- Severity. critical
-- What triggers it. Usage of the Play Age Signals API (com.google.android.play:age-signals) in conjunction with advertising, marketing, user profiling, or analytics libraries, which violates Google Play's strict Terms of Service.
-- How to fix it. Ensure that information from the Play Age Signals API is solely used to provide age-appropriate content and experiences in compliance with laws. Do not use the API or its returned signals for advertising, marketing, user profiling, or analytics.
-- Detection signals. com.google.android.play:age-signals, AgeSignalsManager, AgeSignalsRequest
-
-How to detect.
-
-```bash
-grep -rn 'com.google.android.play:age-signals\|AgeSignalsManager\|AgeSignalsRequest' --include='*.gradle' --include='*.kts' --include='*.kt' --include='*.java' .   # if present, confirm age signals are never passed to ad, marketing, profiling, or analytics SDKs
+grep -rn 'HealthConnectClient\|com.google.android.gms.permission.HealthConnect\|READ_STEPS\|READ_HEART_RATE' --include='*.kt' --include='*.java' --include='AndroidManifest.xml' . && ! grep -rn 'healthConnectConsent\|healthPrivacyPolicy\|Health Connect' .
 ```
 
 ## ANDROID-USER-DATA-DISCLOSURE
@@ -131,37 +36,215 @@ How to detect.
 grep -rn 'contacts\|SMS\|device accounts\|files\|personalData' --include='*.kt' --include='*.java' --include='*.xml' . && ! grep -rn 'prominent disclosure\|user consent\|privacy consent\|accept policy' .
 ```
 
-## ANDROID-HEALTH-PERMISSIONS
+## GOOGLE-DATASAFETY-MISMATCH
 
-- Title. Health or fitness data access without Health Connect declaration
+- Title. Data Safety form does not match runtime behavior
+- Platform. google
+- Guideline or policy. Data Safety
+- Severity. critical
+- What triggers it. Analytics, ads, or tracking SDKs are present that collect or share data not declared in the Data Safety section. This is the number one Google rejection cause.
+- How to fix it. Audit every SDK and runtime data flow and declare every collection, sharing, and security practice accurately in the Data Safety form.
+- Detection signals. firebase-analytics, com.google.android.gms.ads, facebook, appsflyer, adjust
+
+How to detect.
+
+```bash
+grep -rn 'firebase-analytics\|com.google.android.gms.ads\|appsflyer\|adjust\|com.facebook' --include='*.gradle' --include='*.kts' .   # every SDK that collects or shares data must be declared in Data Safety
+```
+
+## GOOGLE-FAMILIES-AD-SDK
+
+- Title. Non compliant ad SDK in a child targeted app
+- Platform. google
+- Guideline or policy. Families
+- Severity. critical
+- What triggers it. An app declared for children uses an ad SDK that is not Families certified, or shows behavioral ads to minors.
+- How to fix it. Use only Families certified ad SDKs and remove behavioral advertising to minors.
+- Detection signals. children, Designed for Families, kids
+
+How to detect.
+
+```bash
+grep -rn 'com.google.android.gms.ads\|applovin\|unity.*ads\|ironsource' --include='*.gradle' . && grep -rni 'children\|families\|kids' --include='AndroidManifest.xml' .
+```
+
+## GOOGLE-PERM-ACCESSIBILITY-MISUSE
+
+- Title. AccessibilityService used for non accessibility purposes
 - Platform. google
 - Guideline or policy. Permissions and APIs
 - Severity. critical
-- What triggers it. Accessing Health Connect client or querying health permissions (e.g. steps, heart rate) without proper declaration or dedicated health privacy policy.
-- How to fix it. Declare Health Connect permissions, complete the console Health Connect form, and maintain a dedicated health privacy policy.
-- Detection signals. HealthConnectClient, com.google.android.gms.permission.HealthConnect, READ_STEPS, READ_HEART_RATE
-- Present means handled. healthConnectConsent, healthPrivacyPolicy, Health Connect
+- What triggers it. BIND_ACCESSIBILITY_SERVICE declared in an app that is not an accessibility tool.
+- How to fix it. Use accessibility APIs only for genuine accessibility features and declare the use, or remove the service.
+- Detection signals. BIND_ACCESSIBILITY_SERVICE, AccessibilityService
 
 How to detect.
 
 ```bash
-grep -rn 'HealthConnectClient\|com.google.android.gms.permission.HealthConnect\|READ_STEPS\|READ_HEART_RATE' --include='*.kt' --include='*.java' --include='AndroidManifest.xml' . && ! grep -rn 'healthConnectConsent\|healthPrivacyPolicy\|Health Connect' .
+grep -rn 'BIND_ACCESSIBILITY_SERVICE\|AccessibilityService' --include='AndroidManifest.xml' --include='*.kt' --include='*.java' .
 ```
 
-## GOOGLE-TARGET-API
+## GOOGLE-PERM-ALL-FILES
 
-- Title. App does not target the current required API level
+- Title. All files access without a qualifying use case
 - Platform. google
-- Guideline or policy. Target API level
-- Severity. high
-- What triggers it. targetSdkVersion in build.gradle is below the current Google Play requirement. From 31 August 2026, new apps and updates must target Android 16, API level 36, or higher.
-- How to fix it. Build against the current required Android target API level. From 31 August 2026 that is API 36 or higher. Submissions below the threshold are rejected automatically.
-- Detection signals. targetSdkVersion, targetSdk
+- Guideline or policy. Permissions and APIs
+- Severity. critical
+- What triggers it. MANAGE_EXTERNAL_STORAGE declared in AndroidManifest.
+- How to fix it. Use scoped storage. Request all files access only for a qualifying use case with the required declaration.
+- Detection signals. MANAGE_EXTERNAL_STORAGE
 
 How to detect.
 
 ```bash
-grep -rnE 'targetSdk(Version)?[ =]+[0-9]+' --include='*.gradle' --include='*.kts' .   # must be 36 or higher from 31 Aug 2026
+grep -rn 'MANAGE_EXTERNAL_STORAGE' --include='AndroidManifest.xml' .
+```
+
+## GOOGLE-PERM-BACKGROUND-LOCATION
+
+- Title. Background location without a qualifying core feature
+- Platform. google
+- Guideline or policy. Permissions and APIs
+- Severity. critical
+- What triggers it. ACCESS_BACKGROUND_LOCATION declared in AndroidManifest with no clear core feature or prominent disclosure.
+- How to fix it. Use foreground location where possible, or justify background use with a core feature and a prominent disclosure and the permission declaration.
+- Detection signals. ACCESS_BACKGROUND_LOCATION
+
+How to detect.
+
+```bash
+grep -rn 'ACCESS_BACKGROUND_LOCATION' --include='AndroidManifest.xml' .
+```
+
+## GOOGLE-PERM-SMS-CALLLOG
+
+- Title. SMS or Call Log without an approved core use case
+- Platform. google
+- Guideline or policy. Permissions and APIs
+- Severity. critical
+- What triggers it. READ_SMS, SEND_SMS, RECEIVE_SMS, READ_CALL_LOG, or WRITE_CALL_LOG declared without an approved use case.
+- How to fix it. Use the permissions declaration form for an approved core use case, or drop the permission.
+- Detection signals. READ_SMS, SEND_SMS, RECEIVE_SMS, READ_CALL_LOG, WRITE_CALL_LOG
+
+How to detect.
+
+```bash
+grep -rnE 'permission.(READ_SMS|SEND_SMS|RECEIVE_SMS|READ_CALL_LOG|WRITE_CALL_LOG)' --include='AndroidManifest.xml' .
+```
+
+## GOOGLE-PLAY-AGE-SIGNALS-MISUSE
+
+- Title. Misuse of Play Age Signals API
+- Platform. google
+- Guideline or policy. User Data
+- Severity. critical
+- What triggers it. Usage of the Play Age Signals API (com.google.android.play:age-signals) in conjunction with advertising, marketing, user profiling, or analytics libraries, which violates Google Play's strict Terms of Service.
+- How to fix it. Ensure that information from the Play Age Signals API is solely used to provide age-appropriate content and experiences in compliance with laws. Do not use the API or its returned signals for advertising, marketing, user profiling, or analytics.
+- Detection signals. com.google.android.play:age-signals, AgeSignalsManager, AgeSignalsRequest
+
+How to detect.
+
+```bash
+grep -rn 'com.google.android.play:age-signals\|AgeSignalsManager\|AgeSignalsRequest' --include='*.gradle' --include='*.kts' --include='*.kt' --include='*.java' .   # if present, confirm age signals are never passed to ad, marketing, profiling, or analytics SDKs
+```
+
+## ANDROID-ADVERTISING-ID
+
+- Title. Google Play Advertising ID usage without disclosure or opt-out
+- Platform. google
+- Guideline or policy. User Data
+- Severity. high
+- What triggers it. Using com.google.android.gms.permission.AD_ID permission or querying GAID but lacking opt-out support or user deletion pathways in code/privacy policy.
+- How to fix it. Declare the AD_ID permission in AndroidManifest.xml and handle user opt-out or deletion requests in full compliance with Google Play policy.
+- Detection signals. com.google.android.gms.permission.AD_ID, AD_ID, getAdvertisingIdInfo
+- Present means handled. opt-out, reset AD_ID, advertisingIdConsent, delete AD_ID
+
+How to detect.
+
+```bash
+grep -rn 'com.google.android.gms.permission.AD_ID\|AD_ID\|getAdvertisingIdInfo' --include='AndroidManifest.xml' --include='*.kt' --include='*.java' . && ! grep -rn 'opt-out\|reset AD_ID\|advertisingIdConsent\|delete AD_ID' .
+```
+
+## ANDROID-DYNAMIC-CODE-LOADING
+
+- Title. Dynamic code loading at runtime
+- Platform. google
+- Guideline or policy. Device and Network Abuse
+- Severity. high
+- What triggers it. DexClassLoader, PathClassLoader from a downloaded file, or downloading and executing code at runtime.
+- How to fix it. Ship all code in the package. Server side changes must be data, not executable code.
+- Detection signals. DexClassLoader, PathClassLoader, loadDex, createPackageContext
+
+How to detect.
+
+```bash
+grep -rn 'DexClassLoader\|PathClassLoader\|loadDex\|createPackageContext' --include='*.kt' --include='*.java' .
+```
+
+## ANDROID-INSECURE-BACKUP
+
+- Title. Android backup is enabled without filtering sensitive data
+- Platform. google
+- Guideline or policy. Device and Network Abuse
+- Severity. high
+- What triggers it. android:allowBackup is set to true in AndroidManifest.xml without setting data extraction rules to exclude credentials/databases.
+- How to fix it. Disable backups with allowBackup="false", or configure dataExtractionRules / fullBackupContent to exclude sensitive credentials and SQLite databases.
+- Detection signals. allowBackup="true"
+- Present means handled. dataExtractionRules, fullBackupContent, allowBackup="false"
+
+How to detect.
+
+```bash
+grep -rn 'allowBackup="true"' . && ! grep -rn 'dataExtractionRules\|fullBackupContent\|allowBackup="false"' .
+```
+
+## ANDROID-OVERLAY-TAPJACKING
+
+- Title. System overlay permission, a tapjacking and malware signal
+- Platform. google
+- Guideline or policy. Permissions and APIs
+- Severity. high
+- What triggers it. SYSTEM_ALERT_WINDOW or application overlay declared, especially combined with AccessibilityService.
+- How to fix it. Remove overlay abuse. The overlay plus accessibility combination is a strong malware signal Google enforces against.
+- Detection signals. SYSTEM_ALERT_WINDOW, TYPE_APPLICATION_OVERLAY
+
+How to detect.
+
+```bash
+grep -rn 'SYSTEM_ALERT_WINDOW\|TYPE_APPLICATION_OVERLAY' --include='AndroidManifest.xml' --include='*.kt' --include='*.java' .
+```
+
+## ANDROID-QUERY-ALL-PACKAGES
+
+- Title. QUERY_ALL_PACKAGES without a permitted use case
+- Platform. google
+- Guideline or policy. Package visibility
+- Severity. high
+- What triggers it. QUERY_ALL_PACKAGES declared in AndroidManifest.
+- How to fix it. Declare specific packages with a queries element, or qualify for a permitted use case.
+- Detection signals. QUERY_ALL_PACKAGES
+
+How to detect.
+
+```bash
+grep -rn 'QUERY_ALL_PACKAGES' --include='AndroidManifest.xml' .
+```
+
+## ANDROID-RUNTIME-PERMISSIONS
+
+- Title. Sensitive runtime permissions requested without validation
+- Platform. google
+- Guideline or policy. Permissions and APIs
+- Severity. high
+- What triggers it. Requesting critical permissions (camera, contacts, storage) without dynamic checks or explicit explanation/rationale to the user.
+- How to fix it. Check permissions dynamically at runtime, show a clear rationale if denied, and handle denials gracefully.
+- Detection signals. requestPermissions, checkSelfPermission, shouldShowRequestPermissionRationale
+- Present means handled. permission explanation, showPermissionRationale, explainPermission
+
+How to detect.
+
+```bash
+grep -rn 'requestPermissions\|checkSelfPermission\|shouldShowRequestPermissionRationale' --include='*.kt' --include='*.java' . && ! grep -rn 'permission explanation\|showPermissionRationale\|explainPermission' .
 ```
 
 ## GOOGLE-12-TESTER-RULE
@@ -182,119 +265,20 @@ grep -rnE 'targetSdk(Version)?[ =]+[0-9]+' --include='*.gradle' --include='*.kts
 - What triggers it. Manual check. The store listing, screenshots, and description must match the app's actual functionality.
 - How to fix it. Make the listing match the build exactly, with screenshots of real in app screens.
 
-## ANDROID-DYNAMIC-CODE-LOADING
+## GOOGLE-TARGET-API
 
-- Title. Dynamic code loading at runtime
+- Title. App does not target the current required API level
 - Platform. google
-- Guideline or policy. Device and Network Abuse
+- Guideline or policy. Target API level
 - Severity. high
-- What triggers it. DexClassLoader, PathClassLoader from a downloaded file, or downloading and executing code at runtime.
-- How to fix it. Ship all code in the package. Server side changes must be data, not executable code.
-- Detection signals. DexClassLoader, PathClassLoader, loadDex, createPackageContext
+- What triggers it. targetSdkVersion in build.gradle is below the current Google Play requirement. From 31 August 2026, new apps and updates must target Android 16, API level 36, or higher.
+- How to fix it. Build against the current required Android target API level. From 31 August 2026 that is API 36 or higher. Submissions below the threshold are rejected automatically.
+- Detection signals. targetSdkVersion, targetSdk
 
 How to detect.
 
 ```bash
-grep -rn 'DexClassLoader\|PathClassLoader\|loadDex\|createPackageContext' --include='*.kt' --include='*.java' .
-```
-
-## ANDROID-QUERY-ALL-PACKAGES
-
-- Title. QUERY_ALL_PACKAGES without a permitted use case
-- Platform. google
-- Guideline or policy. Package visibility
-- Severity. high
-- What triggers it. QUERY_ALL_PACKAGES declared in AndroidManifest.
-- How to fix it. Declare specific packages with a queries element, or qualify for a permitted use case.
-- Detection signals. QUERY_ALL_PACKAGES
-
-How to detect.
-
-```bash
-grep -rn 'QUERY_ALL_PACKAGES' --include='AndroidManifest.xml' .
-```
-
-## ANDROID-OVERLAY-TAPJACKING
-
-- Title. System overlay permission, a tapjacking and malware signal
-- Platform. google
-- Guideline or policy. Permissions and APIs
-- Severity. high
-- What triggers it. SYSTEM_ALERT_WINDOW or application overlay declared, especially combined with AccessibilityService.
-- How to fix it. Remove overlay abuse. The overlay plus accessibility combination is a strong malware signal Google enforces against.
-- Detection signals. SYSTEM_ALERT_WINDOW, TYPE_APPLICATION_OVERLAY
-
-How to detect.
-
-```bash
-grep -rn 'SYSTEM_ALERT_WINDOW\|TYPE_APPLICATION_OVERLAY' --include='AndroidManifest.xml' --include='*.kt' --include='*.java' .
-```
-
-## ANDROID-ADVERTISING-ID
-
-- Title. Google Play Advertising ID usage without disclosure or opt-out
-- Platform. google
-- Guideline or policy. User Data
-- Severity. high
-- What triggers it. Using com.google.android.gms.permission.AD_ID permission or querying GAID but lacking opt-out support or user deletion pathways in code/privacy policy.
-- How to fix it. Declare the AD_ID permission in AndroidManifest.xml and handle user opt-out or deletion requests in full compliance with Google Play policy.
-- Detection signals. com.google.android.gms.permission.AD_ID, AD_ID, getAdvertisingIdInfo
-- Present means handled. opt-out, reset AD_ID, advertisingIdConsent, delete AD_ID
-
-How to detect.
-
-```bash
-grep -rn 'com.google.android.gms.permission.AD_ID\|AD_ID\|getAdvertisingIdInfo' --include='AndroidManifest.xml' --include='*.kt' --include='*.java' . && ! grep -rn 'opt-out\|reset AD_ID\|advertisingIdConsent\|delete AD_ID' .
-```
-
-## ANDROID-RUNTIME-PERMISSIONS
-
-- Title. Sensitive runtime permissions requested without validation
-- Platform. google
-- Guideline or policy. Permissions and APIs
-- Severity. high
-- What triggers it. Requesting critical permissions (camera, contacts, storage) without dynamic checks or explicit explanation/rationale to the user.
-- How to fix it. Check permissions dynamically at runtime, show a clear rationale if denied, and handle denials gracefully.
-- Detection signals. requestPermissions, checkSelfPermission, shouldShowRequestPermissionRationale
-- Present means handled. permission explanation, showPermissionRationale, explainPermission
-
-How to detect.
-
-```bash
-grep -rn 'requestPermissions\|checkSelfPermission\|shouldShowRequestPermissionRationale' --include='*.kt' --include='*.java' . && ! grep -rn 'permission explanation\|showPermissionRationale\|explainPermission' .
-```
-
-## ANDROID-INSECURE-BACKUP
-
-- Title. Android backup is enabled without filtering sensitive data
-- Platform. google
-- Guideline or policy. Device and Network Abuse
-- Severity. high
-- What triggers it. android:allowBackup is set to true in AndroidManifest.xml without setting data extraction rules to exclude credentials/databases.
-- How to fix it. Disable backups with allowBackup="false", or configure dataExtractionRules / fullBackupContent to exclude sensitive credentials and SQLite databases.
-- Detection signals. allowBackup="true"
-- Present means handled. dataExtractionRules, fullBackupContent, allowBackup="false"
-
-How to detect.
-
-```bash
-grep -rn 'allowBackup="true"' . && ! grep -rn 'dataExtractionRules\|fullBackupContent\|allowBackup="false"' .
-```
-
-## ANDROID-ACCESSIBILITY-TALKBACK
-
-- Title. TalkBack support missing or disabled
-- Platform. google
-- Guideline or policy. User Experience - Accessibility
-- Severity. medium
-- What triggers it. Views or graphic components missing contentDescription or setting importantForAccessibility inappropriately.
-- How to fix it. Provide meaningful contentDescription values for all informative images and interactive views, and ensure importantForAccessibility is set correctly.
-- Detection signals. contentDescription, importantForAccessibility
-
-How to detect.
-
-```bash
-python3 scripts/accessibility-audit.py . --rule ANDROID-ACCESSIBILITY-TALKBACK
+grep -rnE 'targetSdk(Version)?[ =]+[0-9]+' --include='*.gradle' --include='*.kts' .   # must be 36 or higher from 31 Aug 2026
 ```
 
 ## ANDROID-ACCESSIBILITY-FONTSCALING
@@ -343,4 +327,20 @@ How to detect.
 
 ```bash
 python3 scripts/accessibility-audit.py . --rule ANDROID-ACCESSIBILITY-SCANNER
+```
+
+## ANDROID-ACCESSIBILITY-TALKBACK
+
+- Title. TalkBack support missing or disabled
+- Platform. google
+- Guideline or policy. User Experience - Accessibility
+- Severity. medium
+- What triggers it. Views or graphic components missing contentDescription or setting importantForAccessibility inappropriately.
+- How to fix it. Provide meaningful contentDescription values for all informative images and interactive views, and ensure importantForAccessibility is set correctly.
+- Detection signals. contentDescription, importantForAccessibility
+
+How to detect.
+
+```bash
+python3 scripts/accessibility-audit.py . --rule ANDROID-ACCESSIBILITY-TALKBACK
 ```

--- a/references/rules/design.md
+++ b/references/rules/design.md
@@ -2,22 +2,6 @@
 
 4 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
 
-## IONIC-4.2-THIN-WRAPPER
-
-- Title. Thin WebView wrapper with insufficient native functionality
-- Platform. apple
-- Guideline or policy. 4.2
-- Severity. critical
-- What triggers it. A Capacitor/Cordova/WKWebView marker is present alongside fewer than 2 distinct native-feel plugins (status bar, splash screen, push notifications, haptics, share, camera, local notifications).
-- How to fix it. Apple 4.2 Minimum Functionality is the single most common Ionic rejection. Add native Capacitor/Cordova plugins for status bar, splash transition, push, and haptics, or ship as an installable PWA to skip App Review.
-- Detection signals. WKWebView, Capacitor, Cordova
-
-How to detect.
-
-```bash
-grep -rlE 'WKWebView|loadRequest|Capacitor|Cordova' --include='*.ts' --include='*.js' --include='*.swift' . 2>/dev/null | wc -l   # then count distinct @capacitor/(status-bar|splash-screen|push-notifications|haptics) markers, fewer than 2 is a thin wrapper
-```
-
 ## APPLE-4.0-SIWA-UX
 
 - Title. Sign in with Apple UX violation
@@ -66,4 +50,20 @@ How to detect.
 
 ```bash
 grep -rn 'FacebookLogin\|GoogleSignIn\|GIDSignIn' --include='*.swift' . && ! grep -rn 'SignInWithApple\|ASAuthorizationAppleIDProvider' --include='*.swift' .
+```
+
+## IONIC-4.2-THIN-WRAPPER
+
+- Title. Thin WebView wrapper with insufficient native functionality
+- Platform. apple
+- Guideline or policy. 4.2
+- Severity. high
+- What triggers it. A Capacitor/Cordova/WKWebView marker is present alongside fewer than 2 distinct native-feel plugins (status bar, splash screen, push notifications, haptics, share, camera, local notifications). This is a heuristic proxy for the real Apple 4.2 test (features/content/UI beyond a repackaged website), reviewed manually before treating as a blocker.
+- How to fix it. Apple 4.2 Minimum Functionality is the single most common Ionic rejection. Add native Capacitor/Cordova plugins for status bar, splash transition, push, and haptics, or ship as an installable PWA to skip App Review.
+- Detection signals. WKWebView, Capacitor, Cordova
+
+How to detect.
+
+```bash
+grep -rlE 'WKWebView|loadRequest|Capacitor|Cordova' --include='*.ts' --include='*.js' --include='*.swift' . 2>/dev/null | wc -l   # then count distinct @capacitor/(status-bar|splash-screen|push-notifications|haptics) markers, fewer than 2 is a thin wrapper
 ```

--- a/references/rules/design.md
+++ b/references/rules/design.md
@@ -1,22 +1,38 @@
 # Rules. Design and login
 
-3 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
+4 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
 
-## APPLE-4.8-SOCIAL-LOGIN-ONLY
+## IONIC-4.2-THIN-WRAPPER
 
-- Title. Third party social login without an equal alternative
+- Title. Thin WebView wrapper with insufficient native functionality
 - Platform. apple
-- Guideline or policy. 4.8
-- Severity. high
-- What triggers it. Facebook, Google, or similar social login is present without Sign in with Apple or an equal privacy preserving option.
-- How to fix it. Add Sign in with Apple or an equal login that limits data to name and email and allows a private email.
-- Detection signals. FacebookLogin, GoogleSignIn, GIDSignIn, LoginWithFacebook
-- Present means handled. SignInWithApple, ASAuthorizationAppleIDProvider
+- Guideline or policy. 4.2
+- Severity. critical
+- What triggers it. A Capacitor/Cordova/WKWebView marker is present alongside fewer than 2 distinct native-feel plugins (status bar, splash screen, push notifications, haptics, share, camera, local notifications).
+- How to fix it. Apple 4.2 Minimum Functionality is the single most common Ionic rejection. Add native Capacitor/Cordova plugins for status bar, splash transition, push, and haptics, or ship as an installable PWA to skip App Review.
+- Detection signals. WKWebView, Capacitor, Cordova
 
 How to detect.
 
 ```bash
-grep -rn 'FacebookLogin\|GoogleSignIn\|GIDSignIn' --include='*.swift' . && ! grep -rn 'SignInWithApple\|ASAuthorizationAppleIDProvider' --include='*.swift' .
+grep -rlE 'WKWebView|loadRequest|Capacitor|Cordova' --include='*.ts' --include='*.js' --include='*.swift' . 2>/dev/null | wc -l   # then count distinct @capacitor/(status-bar|splash-screen|push-notifications|haptics) markers, fewer than 2 is a thin wrapper
+```
+
+## APPLE-4.0-SIWA-UX
+
+- Title. Sign in with Apple UX violation
+- Platform. apple
+- Guideline or policy. 4.0
+- Severity. high
+- What triggers it. Asking for name or email again after Sign in with Apple already provided them, a non standard SIWA button, hiding SIWA below other social logins, or rejecting a private relay email.
+- How to fix it. Use the name and email from the Apple credential, do not re ask, use the standard SIWA button, keep SIWA at least as prominent as other logins, and accept private relay emails. Source. truongduy2611 sign_in_with_apple rule.
+- Detection signals. ASAuthorizationAppleIDProvider, SignInWithApple
+- Present means handled. ASAuthorizationAppleIDButton, privaterelay.appleid.com
+
+How to detect.
+
+```bash
+grep -rn 'ASAuthorizationAppleIDProvider' --include='*.swift' . && grep -rn 'completeProfile\|askForName\|nameTextField\|emailTextField' --include='*.swift' .   # asking for name or email after SIWA is a violation
 ```
 
 ## APPLE-4.2-WEB-WRAPPER
@@ -35,19 +51,19 @@ How to detect.
 grep -rn 'WKWebView\|loadRequest\|Capacitor\|Cordova' --include='*.swift' . | wc -l   # a high count with little native code is a thin wrapper
 ```
 
-## APPLE-4.0-SIWA-UX
+## APPLE-4.8-SOCIAL-LOGIN-ONLY
 
-- Title. Sign in with Apple UX violation
+- Title. Third party social login without an equal alternative
 - Platform. apple
-- Guideline or policy. 4.0
+- Guideline or policy. 4.8
 - Severity. high
-- What triggers it. Asking for name or email again after Sign in with Apple already provided them, a non standard SIWA button, hiding SIWA below other social logins, or rejecting a private relay email.
-- How to fix it. Use the name and email from the Apple credential, do not re ask, use the standard SIWA button, keep SIWA at least as prominent as other logins, and accept private relay emails. Source. truongduy2611 sign_in_with_apple rule.
-- Detection signals. ASAuthorizationAppleIDProvider, SignInWithApple
-- Present means handled. ASAuthorizationAppleIDButton, privaterelay.appleid.com
+- What triggers it. Facebook, Google, or similar social login is present without Sign in with Apple or an equal privacy preserving option.
+- How to fix it. Add Sign in with Apple or an equal login that limits data to name and email and allows a private email.
+- Detection signals. FacebookLogin, GoogleSignIn, GIDSignIn, LoginWithFacebook
+- Present means handled. SignInWithApple, ASAuthorizationAppleIDProvider
 
 How to detect.
 
 ```bash
-grep -rn 'ASAuthorizationAppleIDProvider' --include='*.swift' . && grep -rn 'completeProfile\|askForName\|nameTextField\|emailTextField' --include='*.swift' .   # asking for name or email after SIWA is a violation
+grep -rn 'FacebookLogin\|GoogleSignIn\|GIDSignIn' --include='*.swift' . && ! grep -rn 'SignInWithApple\|ASAuthorizationAppleIDProvider' --include='*.swift' .
 ```

--- a/references/rules/metadata.md
+++ b/references/rules/metadata.md
@@ -11,6 +11,15 @@
 - What triggers it. Manual check. The updated age rating questions (13 plus, 16 plus, 18 plus) must be answered by 31 January 2026 to submit updates.
 - How to fix it. Answer the updated age rating questionnaire in App Store Connect for every app.
 
+## APPLE-5.2.5-APPLE-DEVICE-IMAGE
+
+- Title. Apple device image or Apple trademark in the icon or screenshots
+- Platform. apple
+- Guideline or policy. 5.2.5
+- Severity. high
+- What triggers it. Manual metadata check. The app icon or screenshots show an Apple device, the Apple logo, or imply Apple endorsement.
+- How to fix it. Remove Apple device images and Apple marks from the icon and screenshots. Source. truongduy2611 apple_trademark rule.
+
 ## BOTH-UNREACHABLE-METADATA-URL
 
 - Title. Broken support, marketing, or privacy URL in the listing
@@ -25,15 +34,6 @@ How to detect.
 ```bash
 python3 scripts/metadata-audit.py ./metadata --check-urls
 ```
-
-## APPLE-5.2.5-APPLE-DEVICE-IMAGE
-
-- Title. Apple device image or Apple trademark in the icon or screenshots
-- Platform. apple
-- Guideline or policy. 5.2.5
-- Severity. high
-- What triggers it. Manual metadata check. The app icon or screenshots show an Apple device, the Apple logo, or imply Apple endorsement.
-- How to fix it. Remove Apple device images and Apple marks from the icon and screenshots. Source. truongduy2611 apple_trademark rule.
 
 ## CHINA-AI-REFERENCES
 
@@ -53,21 +53,6 @@ python3 scripts/metadata-audit.py ./metadata --check-urls
 - What triggers it. Strings such as Android, Google Play, or alternative marketplace names found in app facing copy or metadata.
 - How to fix it. Remove references to other platforms and marketplaces from the app and metadata.
 - Detection signals. Google Play, available on Android, download on the Play Store
-
-How to detect.
-
-```bash
-python3 scripts/metadata-audit.py ./metadata
-```
-
-## BOTH-METADATA-DECORATION
-
-- Title. Metadata field overflow or banned decoration
-- Platform. both
-- Guideline or policy. Apple 2.3.7, Google Store Listing
-- Severity. medium
-- What triggers it. App name over the limit (Apple 30, Google 30), emoji in the title, all caps, or ranking and price claims such as number one, best, top, or free in the title or icon.
-- How to fix it. Keep each metadata field within its limit and remove emoji, all caps, and ranking or price claims from the title and icon.
 
 How to detect.
 
@@ -115,3 +100,18 @@ python3 scripts/metadata-audit.py ./metadata
 - Severity. medium
 - What triggers it. Manual metadata check. The app preview video wraps the app in a device frame instead of showing the app full screen.
 - How to fix it. Capture the preview video full screen from the device, without a device frame overlay.
+
+## BOTH-METADATA-DECORATION
+
+- Title. Metadata field overflow or banned decoration
+- Platform. both
+- Guideline or policy. Apple 2.3.7, Google Store Listing
+- Severity. medium
+- What triggers it. App name over the limit (Apple 30, Google 30), emoji in the title, all caps, or ranking and price claims such as number one, best, top, or free in the title or icon.
+- How to fix it. Keep each metadata field within its limit and remove emoji, all caps, and ranking or price claims from the title and icon.
+
+How to detect.
+
+```bash
+python3 scripts/metadata-audit.py ./metadata
+```

--- a/references/rules/payments.md
+++ b/references/rules/payments.md
@@ -19,6 +19,22 @@ How to detect.
 grep -rn 'Stripe\|PayPalCheckout\|braintree\|razorpay' --include='*.swift' . && ! grep -rn 'StoreKit\|SKProduct\|Product.purchase' --include='*.swift' .
 ```
 
+## APPLE-GAMBLING-BRAZIL-LICENSE
+
+- Title. Missing Brazilian fixed-odds betting license
+- Platform. apple
+- Guideline or policy. 3.1.1
+- Severity. critical
+- What triggers it. An app that indicates gambling/betting features but does not provide a valid fixed-odds betting license from the Secretariat of Prizes and Bets (SPA) in its App Review Information section when distributing on the Brazil storefront.
+- How to fix it. Select 'Yes' to the gambling question in the age rating questionnaire (which automatically sets the Brazil age rating to A18), provide a valid fixed-odds betting license from the Secretariat of Prizes and Bets (SPA) in the App Review Information field, and submit a new app version for verification.
+- Detection signals. gambling, fixed-odds betting, Secretariat of Prizes and Bets, SPA license
+
+How to detect.
+
+```bash
+grep -rni 'gambling\|fixed-odds\|betting' --include='*.swift' .   # then verify the SPA license is provided in App Review Information for Brazil storefront
+```
+
 ## GOOGLE-PLAY-BILLING
 
 - Title. Digital goods sold without Play Billing
@@ -36,36 +52,19 @@ How to detect.
 grep -rn 'Stripe\|PayPal\|razorpay' --include='*.kt' --include='*.java' . && ! grep -rn 'BillingClient\|com.android.billingclient' .
 ```
 
-## APPLE-GAMBLING-BRAZIL-LICENSE
+## APPLE-3.1.2-MISLEADING-PRICING
 
-- Title. Missing Brazilian fixed-odds betting license
+- Title. Subscription shows the per month price more prominently than the billed amount
 - Platform. apple
-- Guideline or policy. 3.1.1
-- Severity. critical
-- What triggers it. An app that indicates gambling/betting features but does not provide a valid fixed-odds betting license from the Secretariat of Prizes and Bets (SPA) in its App Review Information section when distributing on the Brazil storefront.
-- How to fix it. Select 'Yes' to the gambling question in the age rating questionnaire (which automatically sets the Brazil age rating to A18), provide a valid fixed-odds betting license from the Secretariat of Prizes and Bets (SPA) in the App Review Information field, and submit a new app version for verification.
-- Detection signals. gambling, fixed-odds betting, Secretariat of Prizes and Bets, SPA license
-
-How to detect.
-
-```bash
-grep -rni 'gambling\|fixed-odds\|betting' --include='*.swift' .   # then verify the SPA license is provided in App Review Information for Brazil storefront
-```
-
-## BOTH-LOOTBOX-ODDS
-
-- Title. Random reward mechanic without disclosed odds
-- Platform. both
-- Guideline or policy. Apple 3.1.1, Google gambling
+- Guideline or policy. 3.1.2
 - Severity. high
-- What triggers it. Loot box, gacha, or random reward purchase present without odds disclosed before purchase.
-- How to fix it. Disclose the odds for every random reward before the user purchases.
-- Detection signals. lootbox, loot box, gacha, random reward, mystery box
+- What triggers it. Manual paywall check. An annual subscription shows a small per month figure large and the actual billed total small.
+- How to fix it. Show the actual amount the user will be charged at least as prominently as any per month figure. Source. truongduy2611 misleading_pricing rule.
 
 How to detect.
 
 ```bash
-grep -rni 'lootbox\|loot box\|gacha\|mystery box\|random reward' .
+python3 scripts/metadata-audit.py ./metadata
 ```
 
 ## APPLE-RESTORE-PURCHASES-MISSING
@@ -85,19 +84,20 @@ How to detect.
 grep -rn 'SKProduct\|Product.purchase\|StoreKit' --include='*.swift' . && ! grep -rn 'restorePurchases\|restoreCompletedTransactions\|AppStore.sync' --include='*.swift' .
 ```
 
-## APPLE-3.1.2-MISLEADING-PRICING
+## BOTH-LOOTBOX-ODDS
 
-- Title. Subscription shows the per month price more prominently than the billed amount
-- Platform. apple
-- Guideline or policy. 3.1.2
+- Title. Random reward mechanic without disclosed odds
+- Platform. both
+- Guideline or policy. Apple 3.1.1, Google gambling
 - Severity. high
-- What triggers it. Manual paywall check. An annual subscription shows a small per month figure large and the actual billed total small.
-- How to fix it. Show the actual amount the user will be charged at least as prominently as any per month figure. Source. truongduy2611 misleading_pricing rule.
+- What triggers it. Loot box, gacha, or random reward purchase present without odds disclosed before purchase.
+- How to fix it. Disclose the odds for every random reward before the user purchases.
+- Detection signals. lootbox, loot box, gacha, random reward, mystery box
 
 How to detect.
 
 ```bash
-python3 scripts/metadata-audit.py ./metadata
+grep -rni 'lootbox\|loot box\|gacha\|mystery box\|random reward' .
 ```
 
 ## BOTH-SUBSCRIPTION-HARD-CANCEL

--- a/references/rules/performance.md
+++ b/references/rules/performance.md
@@ -1,6 +1,22 @@
 # Rules. Performance and completeness
 
-22 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
+24 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
+
+## APPLE-2.1-CLOUD-NOT-IN-PRODUCTION
+
+- Title. iCloud or CloudKit schema not deployed to production
+- Platform. apple
+- Guideline or policy. 2.1
+- Severity. critical
+- What triggers it. The app uses CloudKit or iCloud but the schema and containers are only in the development environment, so the feature fails for the reviewer on the production build.
+- How to fix it. Deploy the CloudKit schema and containers to production before submitting. Source. lukylab checklist.
+- Detection signals. CKContainer, CloudKit, NSUbiquitousKeyValueStore, iCloud
+
+How to detect.
+
+```bash
+grep -rn 'CKContainer\|CloudKit\|NSUbiquitousKeyValueStore' --include='*.swift' .   # then confirm the CloudKit schema is deployed to production in the CloudKit console
+```
 
 ## APPLE-2.1-MISSING-DEMO-ACCOUNT
 
@@ -34,20 +50,20 @@ How to detect.
 grep -rn 'localhost\|127.0.0.1\|staging\.\|ngrok\|http://' --include='*.swift' --include='*.plist' . | grep -v https
 ```
 
-## APPLE-2.1-CLOUD-NOT-IN-PRODUCTION
+## IONIC-UIWEBVIEW-DEPRECATED
 
-- Title. iCloud or CloudKit schema not deployed to production
+- Title. Deprecated UIWebView symbol statically linked
 - Platform. apple
-- Guideline or policy. 2.1
+- Guideline or policy. 2.5.1
 - Severity. critical
-- What triggers it. The app uses CloudKit or iCloud but the schema and containers are only in the development environment, so the feature fails for the reviewer on the production build.
-- How to fix it. Deploy the CloudKit schema and containers to production before submitting. Source. lukylab checklist.
-- Detection signals. CKContainer, CloudKit, NSUbiquitousKeyValueStore, iCloud
+- What triggers it. The literal UIWebView symbol appears anywhere in the built sources, often pulled in transitively by a stale Capacitor or Cordova plugin.
+- How to fix it. Apple auto-rejects (ITMS-90809) any binary statically linking UIWebView. Update every plugin to a WKWebView-based version.
+- Detection signals. UIWebView
 
 How to detect.
 
 ```bash
-grep -rn 'CKContainer\|CloudKit\|NSUbiquitousKeyValueStore' --include='*.swift' .   # then confirm the CloudKit schema is deployed to production in the CloudKit console
+grep -rn 'UIWebView' --include='*.swift' --include='*.m' . 2>/dev/null
 ```
 
 ## WEB-GDPR-COMPLIANCE
@@ -67,6 +83,22 @@ How to detect.
 grep -rn 'processData\|personalData\|submitForm\|registerWeb\|webForm' --include='*.js' --include='*.ts' --include='*.html' . && ! grep -rn 'GDPR\|opt-in\|privacyConsent\|deletePersonalData\|exportData' .
 ```
 
+## APPLE-2.1-DEBUG-FEATURES
+
+- Title. Debug or test features shipped in the production build
+- Platform. apple
+- Guideline or policy. 2.1
+- Severity. high
+- What triggers it. Debug menus, test logins, or developer backdoors left visible in the release build rather than gated behind a debug only flag.
+- How to fix it. Hide debug and test features behind a debug only compile flag so they never ship in production. Source. lukylab checklist.
+- Detection signals. debug menu, debugMenu, test login, skip login, bypass auth, DEBUG_BYPASS
+
+How to detect.
+
+```bash
+grep -rni 'debug menu\|debugMenu\|skip login\|bypass auth\|DEBUG_BYPASS' --include='*.swift' .
+```
+
 ## APPLE-2.1-PLACEHOLDER-CONTENT
 
 - Title. Placeholder content in the build
@@ -81,6 +113,21 @@ How to detect.
 
 ```bash
 grep -rni 'lorem ipsum\|placeholder\|TODO\|FIXME\|example.com' --include='*.swift' --include='*.strings' .
+```
+
+## APPLE-2.1-REVIEW-NOTES-INCOMPLETE
+
+- Title. Review notes missing a required section for a new submission
+- Platform. apple
+- Guideline or policy. 2.1
+- Severity. high
+- What triggers it. New submission review notes omit one of the six sections. Screen recording on a physical device, app purpose, access instructions and test credentials, external services list, regional differences, and regulated industry documentation.
+- How to fix it. Fill all six review notes sections using templates/REVIEW-NOTES-TEMPLATE.md. Source. truongduy2611 review_notes rules.
+
+How to detect.
+
+```bash
+use templates/REVIEW-NOTES-TEMPLATE.md and fill all six sections
 ```
 
 ## APPLE-2.5.1-PRIVATE-API
@@ -99,6 +146,22 @@ How to detect.
 grep -rn 'UIWebView\|performSelector\|valueForKey' --include='*.swift' --include='*.m' .   # review any reflection or deprecated framework use
 ```
 
+## BOTH-E-EVIDENCE-COMPLIANCE-MISSING
+
+- Title. Missing legal representative or emergency data-production response procedures for the EU e-Evidence Package
+- Platform. both
+- Guideline or policy. Regulation (EU) 2023/1543 & Directive (EU) 2023/1544 (EU e-Evidence Package)
+- Severity. high
+- What triggers it. Apps/services processing user data in the EU that fail to designate a legal representative or lack internal procedures to respond to European Production/Preservation Orders within 10 days (or 8 hours for emergencies).
+- How to fix it. Designate an establishment or appoint a legal representative in the EU, notify contact details by August 18, 2026, and establish internal protocols to deliver user data securely within 8 hours in emergency situations.
+- Detection signals. e-Evidence, European Production Order, European Preservation Order, emergency data production, law enforcement request, legal representative
+
+How to detect.
+
+```bash
+grep -rniE 'e-evidence|european production order|european preservation order|emergency data production' . 2>/dev/null
+```
+
 ## BOTH-SDK-SUPPLY-CHAIN
 
 - Title. Third party SDK violates policy on the developer's behalf
@@ -108,35 +171,70 @@ grep -rn 'UIWebView\|performSelector\|valueForKey' --include='*.swift' --include
 - What triggers it. A bundled SDK requests permissions, tracks users, or behaves in ways the app does not declare. The developer is responsible for SDK behavior.
 - How to fix it. Vet every SDK, keep them current, and remove any that collect or share data the app does not declare.
 
-## APPLE-2.1-DEBUG-FEATURES
+## BOTH-SECURE-STORAGE
 
-- Title. Debug or test features shipped in the production build
-- Platform. apple
-- Guideline or policy. 2.1
+- Title. Sensitive tokens or credentials stored in insecure unencrypted formats
+- Platform. both
+- Guideline or policy. Data Security
 - Severity. high
-- What triggers it. Debug menus, test logins, or developer backdoors left visible in the release build rather than gated behind a debug only flag.
-- How to fix it. Hide debug and test features behind a debug only compile flag so they never ship in production. Source. lukylab checklist.
-- Detection signals. debug menu, debugMenu, test login, skip login, bypass auth, DEBUG_BYPASS
+- What triggers it. Sensitive session credentials or tokens are saved directly to unencrypted plist, UserDefaults, or SharedPreferences instead of Keychain or Android Keystore / EncryptedSharedPreferences.
+- How to fix it. Store all sensitive data and access tokens in iOS Keychain or Android EncryptedSharedPreferences.
+- Detection signals. UserDefaults.standard.set, getSharedPreferences
 
 How to detect.
 
 ```bash
-grep -rni 'debug menu\|debugMenu\|skip login\|bypass auth\|DEBUG_BYPASS' --include='*.swift' .
+grep -rn 'UserDefaults.standard.set\|getSharedPreferences' . | grep -i 'token\|password\|credential\|secret\|jwt' && ! grep -rn 'Keychain\|SecItemAdd\|SecItemUpdate\|EncryptedSharedPreferences\|KeyStore\|SQLCipher' .   # matches guard.sh: fires only when a sensitive keyword is present AND a secure-storage API is absent
 ```
 
-## APPLE-2.1-REVIEW-NOTES-INCOMPLETE
+## BOTH-UNSAFE-DEEPLINK
 
-- Title. Review notes missing a required section for a new submission
-- Platform. apple
-- Guideline or policy. 2.1
+- Title. Unsafe or unvalidated custom deep link URL schemes used for sensitive operations
+- Platform. both
+- Guideline or policy. Data Security
 - Severity. high
-- What triggers it. New submission review notes omit one of the six sections. Screen recording on a physical device, app purpose, access instructions and test credentials, external services list, regional differences, and regulated industry documentation.
-- How to fix it. Fill all six review notes sections using templates/REVIEW-NOTES-TEMPLATE.md. Source. truongduy2611 review_notes rules.
+- What triggers it. Relying on custom URL schemes for sensitive routing, navigation, or passing tokens, without strict input validation.
+- How to fix it. Use Universal Links (iOS) and App Links (Android) for secure domain-validated link routing, and sanitize all deep link parameters.
+- Detection signals. CFBundleURLSchemes, android:scheme
+- Present means handled. apple-app-site-association, assetlinks.json
 
 How to detect.
 
 ```bash
-use templates/REVIEW-NOTES-TEMPLATE.md and fill all six sections
+grep -rn 'CFBundleURLSchemes\|android:scheme' . && ! grep -rn 'apple-app-site-association\|assetlinks.json' .
+```
+
+## RN-OTA-UNDECLARED
+
+- Title. Undisclosed over-the-air JS bundle updater
+- Platform. apple
+- Guideline or policy. 3.3.2
+- Severity. high
+- What triggers it. package.json depends on react-native or expo, and an OTA updater (react-native-code-push, expo-updates, react-native-ota-hot-update, Stallion) is present with no App Review disclosure of bug-fix-only scope.
+- How to fix it. Name the OTA mechanism in App Review notes and restrict it to bug fixes that do not change purpose, UI, or features beyond what was reviewed (Apple 3.3.2, 2.5.2).
+- Detection signals. react-native-code-push, CodePush., expo-updates, Stallion
+
+How to detect.
+
+```bash
+grep -rn 'react-native-code-push\|CodePush\.\|expo-updates' --include='*.ts' --include='*.tsx' --include='*.js' . 2>/dev/null
+```
+
+## WEB-INDEXEDDB
+
+- Title. Structured personal data stored in IndexedDB without security controls
+- Platform. web
+- Guideline or policy. GDPR
+- Severity. high
+- What triggers it. Storing user records in IndexedDB without user consent, encryption, or proper deletion lifecycles.
+- How to fix it. Use encrypted IndexedDB wrappers for structured sensitive records, check user consent, and clear databases upon logout.
+- Detection signals. indexedDB.open, indexedDB, createObjectStore
+- Present means handled. encryptDatabase, deleteDatabase, consentIndexedDB
+
+How to detect.
+
+```bash
+grep -rn 'indexedDB.open\|indexedDB\|createObjectStore' --include='*.js' --include='*.ts' --include='*.html' . && ! grep -rn 'encryptDatabase\|deleteDatabase\|consentIndexedDB' .
 ```
 
 ## WEB-LOCAL-STORAGE
@@ -173,23 +271,6 @@ How to detect.
 grep -rn 'sessionStorage.setItem\|sessionStorage' --include='*.js' --include='*.ts' --include='*.html' . && ! grep -rn 'encryptedSession\|clearSessionStorage' .
 ```
 
-## WEB-INDEXEDDB
-
-- Title. Structured personal data stored in IndexedDB without security controls
-- Platform. web
-- Guideline or policy. GDPR
-- Severity. high
-- What triggers it. Storing user records in IndexedDB without user consent, encryption, or proper deletion lifecycles.
-- How to fix it. Use encrypted IndexedDB wrappers for structured sensitive records, check user consent, and clear databases upon logout.
-- Detection signals. indexedDB.open, indexedDB, createObjectStore
-- Present means handled. encryptDatabase, deleteDatabase, consentIndexedDB
-
-How to detect.
-
-```bash
-grep -rn 'indexedDB.open\|indexedDB\|createObjectStore' --include='*.js' --include='*.ts' --include='*.html' . && ! grep -rn 'encryptDatabase\|deleteDatabase\|consentIndexedDB' .
-```
-
 ## WEB-TRACKING-TECHNOLOGIES
 
 - Title. Third-party tracking technologies loaded without consent
@@ -207,69 +288,20 @@ How to detect.
 grep -rn 'gtag\|fbq\|google-analytics\|trackingPixel\|analytics.js\|hotjar' --include='*.js' --include='*.ts' --include='*.html' . && ! grep -rn 'consentTracking\|disableTracking\|optOutTracking\|trackingPreferences' .
 ```
 
-## BOTH-SECURE-STORAGE
+## APPLE-ACCESSIBILITY-COLORCONTRAST
 
-- Title. Sensitive tokens or credentials stored in insecure unencrypted formats
-- Platform. both
-- Guideline or policy. Data Security
-- Severity. high
-- What triggers it. Sensitive session credentials or tokens are saved directly to unencrypted plist, UserDefaults, or SharedPreferences instead of Keychain or Android Keystore / EncryptedSharedPreferences.
-- How to fix it. Store all sensitive data and access tokens in iOS Keychain or Android EncryptedSharedPreferences.
-- Detection signals. UserDefaults.standard.set, getSharedPreferences
-
-How to detect.
-
-```bash
-grep -rn 'UserDefaults.standard.set\|getSharedPreferences' . | grep -i 'token\|password\|credential\|secret\|jwt' && ! grep -rn 'Keychain\|SecItemAdd\|SecItemUpdate\|EncryptedSharedPreferences\|KeyStore\|SQLCipher' .   # matches guard.sh: fires only when a sensitive keyword is present AND a secure-storage API is absent
-```
-
-## BOTH-UNSAFE-DEEPLINK
-
-- Title. Unsafe or unvalidated custom deep link URL schemes used for sensitive operations
-- Platform. both
-- Guideline or policy. Data Security
-- Severity. high
-- What triggers it. Relying on custom URL schemes for sensitive routing, navigation, or passing tokens, without strict input validation.
-- How to fix it. Use Universal Links (iOS) and App Links (Android) for secure domain-validated link routing, and sanitize all deep link parameters.
-- Detection signals. CFBundleURLSchemes, android:scheme
-- Present means handled. apple-app-site-association, assetlinks.json
-
-How to detect.
-
-```bash
-grep -rn 'CFBundleURLSchemes\|android:scheme' . && ! grep -rn 'apple-app-site-association\|assetlinks.json' .
-```
-
-## BOTH-E-EVIDENCE-COMPLIANCE-MISSING
-
-- Title. Missing legal representative or emergency data-production response procedures for the EU e-Evidence Package
-- Platform. both
-- Guideline or policy. Regulation (EU) 2023/1543 & Directive (EU) 2023/1544 (EU e-Evidence Package)
-- Severity. high
-- What triggers it. Apps/services processing user data in the EU that fail to designate a legal representative or lack internal procedures to respond to European Production/Preservation Orders within 10 days (or 8 hours for emergencies).
-- How to fix it. Designate an establishment or appoint a legal representative in the EU, notify contact details by August 18, 2026, and establish internal protocols to deliver user data securely within 8 hours in emergency situations.
-- Detection signals. e-Evidence, European Production Order, European Preservation Order, emergency data production, law enforcement request, legal representative
-
-How to detect.
-
-```bash
-grep -rniE 'e-evidence|european production order|european preservation order|emergency data production' . 2>/dev/null
-```
-
-## APPLE-ACCESSIBILITY-VOICEOVER
-
-- Title. VoiceOver support missing or incomplete
+- Title. Color Contrast and system settings ignored
 - Platform. apple
 - Guideline or policy. Design - Accessibility
 - Severity. medium
-- What triggers it. Interactive views or images without accessibilityLabel, accessibilityIdentifier, isAccessibilityElement, or accessibilityElement(children:) properties.
-- How to fix it. Ensure all interactive components and decorative or informative images have correct accessibility labels, hints, and traits assigned.
-- Detection signals. UIAccessibility, accessibilityLabel, accessibilityIdentifier, isAccessibilityElement
+- What triggers it. Hardcoded custom colors used without supporting dark/light mode, high-contrast settings, or checking isDarkerSystemColorsEnabled.
+- How to fix it. Use dynamic or system colors that automatically adapt, or monitor isDarkerSystemColorsEnabled to adjust contrast dynamically.
+- Detection signals. isDarkerSystemColorsEnabled, darkerSystemColors
 
 How to detect.
 
 ```bash
-python3 scripts/accessibility-audit.py . --rule APPLE-ACCESSIBILITY-VOICEOVER
+python3 scripts/accessibility-audit.py . --rule APPLE-ACCESSIBILITY-COLORCONTRAST
 ```
 
 ## APPLE-ACCESSIBILITY-DYNAMICTYPE
@@ -286,38 +318,6 @@ How to detect.
 
 ```bash
 python3 scripts/accessibility-audit.py . --rule APPLE-ACCESSIBILITY-DYNAMICTYPE
-```
-
-## APPLE-ACCESSIBILITY-REDUCEMOTION
-
-- Title. Reduce Motion accessibility setting ignored
-- Platform. apple
-- Guideline or policy. Design - Accessibility
-- Severity. medium
-- What triggers it. Custom animations or transitions without checks for UIAccessibility.isReduceMotionEnabled or environment accessibilityReduceMotion.
-- How to fix it. Check the Reduce Motion system status and disable or simplify non-essential animations when requested by the user.
-- Detection signals. isReduceMotionEnabled, accessibilityReduceMotion
-
-How to detect.
-
-```bash
-python3 scripts/accessibility-audit.py . --rule APPLE-ACCESSIBILITY-REDUCEMOTION
-```
-
-## APPLE-ACCESSIBILITY-COLORCONTRAST
-
-- Title. Color Contrast and system settings ignored
-- Platform. apple
-- Guideline or policy. Design - Accessibility
-- Severity. medium
-- What triggers it. Hardcoded custom colors used without supporting dark/light mode, high-contrast settings, or checking isDarkerSystemColorsEnabled.
-- How to fix it. Use dynamic or system colors that automatically adapt, or monitor isDarkerSystemColorsEnabled to adjust contrast dynamically.
-- Detection signals. isDarkerSystemColorsEnabled, darkerSystemColors
-
-How to detect.
-
-```bash
-python3 scripts/accessibility-audit.py . --rule APPLE-ACCESSIBILITY-COLORCONTRAST
 ```
 
 ## APPLE-ACCESSIBILITY-HAPTICS
@@ -350,4 +350,36 @@ How to detect.
 
 ```bash
 python3 scripts/accessibility-audit.py . --rule APPLE-ACCESSIBILITY-KEYBOARD
+```
+
+## APPLE-ACCESSIBILITY-REDUCEMOTION
+
+- Title. Reduce Motion accessibility setting ignored
+- Platform. apple
+- Guideline or policy. Design - Accessibility
+- Severity. medium
+- What triggers it. Custom animations or transitions without checks for UIAccessibility.isReduceMotionEnabled or environment accessibilityReduceMotion.
+- How to fix it. Check the Reduce Motion system status and disable or simplify non-essential animations when requested by the user.
+- Detection signals. isReduceMotionEnabled, accessibilityReduceMotion
+
+How to detect.
+
+```bash
+python3 scripts/accessibility-audit.py . --rule APPLE-ACCESSIBILITY-REDUCEMOTION
+```
+
+## APPLE-ACCESSIBILITY-VOICEOVER
+
+- Title. VoiceOver support missing or incomplete
+- Platform. apple
+- Guideline or policy. Design - Accessibility
+- Severity. medium
+- What triggers it. Interactive views or images without accessibilityLabel, accessibilityIdentifier, isAccessibilityElement, or accessibilityElement(children:) properties.
+- How to fix it. Ensure all interactive components and decorative or informative images have correct accessibility labels, hints, and traits assigned.
+- Detection signals. UIAccessibility, accessibilityLabel, accessibilityIdentifier, isAccessibilityElement
+
+How to detect.
+
+```bash
+python3 scripts/accessibility-audit.py . --rule APPLE-ACCESSIBILITY-VOICEOVER
 ```

--- a/references/rules/privacy.md
+++ b/references/rules/privacy.md
@@ -1,6 +1,6 @@
 # Rules. Privacy and data
 
-14 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
+17 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
 
 ## APPLE-5.1.1-MISSING-PRIVACY-POLICY
 
@@ -51,6 +51,39 @@ How to detect.
 grep -rn 'createAccount\|signUp\|register' --include='*.swift' . && ! grep -rn 'deleteAccount\|delete_account\|account deletion' --include='*.swift' .
 ```
 
+## APPLE-PRIVACY-MANIFEST-MISSING
+
+- Title. Required reason APIs or third party SDKs without a privacy manifest
+- Platform. apple
+- Guideline or policy. Privacy Manifest
+- Severity. critical
+- What triggers it. Required reason API usage or a commonly used third party SDK is present but no PrivacyInfo.xcprivacy is bundled, or an SDK lacks its signed manifest. Enforced by Apple at upload since 2024. The top modern Apple upload rejection.
+- How to fix it. Add a PrivacyInfo.xcprivacy with NSPrivacyAccessedAPITypes and approved reason codes, list NSPrivacyTrackingDomains, and confirm every third party SDK ships its signed manifest.
+- Detection signals. NSFileManager, UserDefaults, systemUptime, ProcessInfo, Firebase, Alamofire
+- Present means handled. PrivacyInfo.xcprivacy, NSPrivacyAccessedAPITypes
+
+How to detect.
+
+```bash
+find . -name 'PrivacyInfo.xcprivacy' | grep -q . || echo 'MISSING PrivacyInfo.xcprivacy'; find . -path '*/*.framework/*' -name 'PrivacyInfo.xcprivacy'   # each bundled SDK should ship one
+```
+
+## FLUTTER-PRIVACY-MANIFEST-MISSING
+
+- Title. Flutter plugin touches required-reason APIs with no PrivacyInfo.xcprivacy
+- Platform. apple
+- Guideline or policy. 5.1.1
+- Severity. critical
+- What triggers it. pubspec.yaml present, a plugin known to touch required-reason APIs (permission_handler, image_picker, geolocator, device_info_plus, package_info_plus, shared_preferences, sqflite, firebase_*) is a dependency, and no PrivacyInfo.xcprivacy exists anywhere in the project.
+- How to fix it. Add an app-level PrivacyInfo.xcprivacy and confirm each Flutter plugin ships its own (Flutter 3.19+ plugins mostly do). A missing plugin-level manifest is invisible to Apple unless the app manifest also declares that plugin reason code.
+- Detection signals. pubspec.yaml, permission_handler, image_picker, firebase_
+
+How to detect.
+
+```bash
+grep -q 'permission_handler\|image_picker\|geolocator\|firebase_' pubspec.yaml 2>/dev/null && ! find . -name 'PrivacyInfo.xcprivacy' | grep -q .
+```
+
 ## GOOGLE-MISSING-PRIVACY-POLICY
 
 - Title. Missing privacy policy
@@ -67,21 +100,20 @@ How to detect.
 grep -rn 'privacyPolicy\|privacy-policy' . || echo 'set a privacy policy URL in the Play listing'
 ```
 
-## APPLE-PRIVACY-MANIFEST-MISSING
+## RN-PRIVACY-MANIFEST-MISSING
 
-- Title. Required reason APIs or third party SDKs without a privacy manifest
+- Title. React Native native module touches required-reason APIs with no PrivacyInfo.xcprivacy
 - Platform. apple
-- Guideline or policy. Privacy Manifest
+- Guideline or policy. 5.1.1
 - Severity. critical
-- What triggers it. Required reason API usage or a commonly used third party SDK is present but no PrivacyInfo.xcprivacy is bundled, or an SDK lacks its signed manifest. Enforced by Apple at upload since 2024. The top modern Apple upload rejection.
-- How to fix it. Add a PrivacyInfo.xcprivacy with NSPrivacyAccessedAPITypes and approved reason codes, list NSPrivacyTrackingDomains, and confirm every third party SDK ships its signed manifest.
-- Detection signals. NSFileManager, UserDefaults, systemUptime, ProcessInfo, Firebase, Alamofire
-- Present means handled. PrivacyInfo.xcprivacy, NSPrivacyAccessedAPITypes
+- What triggers it. package.json depends on react-native or expo, native modules with required-reason API usage are present (Firebase, AsyncStorage, expo-file-system), and no PrivacyInfo.xcprivacy exists.
+- How to fix it. Add an app-level PrivacyInfo.xcprivacy. Native modules bundled transitively via JS deps each need their own manifest aggregated in the final IPA.
+- Detection signals. @react-native-firebase, AsyncStorage, expo-file-system
 
 How to detect.
 
 ```bash
-find . -name 'PrivacyInfo.xcprivacy' | grep -q . || echo 'MISSING PrivacyInfo.xcprivacy'; find . -path '*/*.framework/*' -name 'PrivacyInfo.xcprivacy'   # each bundled SDK should ship one
+grep -qE '"react-native"|"expo"' package.json 2>/dev/null && grep -rn 'Firebase\|AsyncStorage\|expo-file-system' --include='*.ts' --include='*.tsx' . 2>/dev/null && ! find . -name 'PrivacyInfo.xcprivacy' | grep -q .
 ```
 
 ## WEB-COOKIE-CONSENT
@@ -101,6 +133,39 @@ How to detect.
 grep -rn 'document.cookie\|setCookie\|cookieStore\|js-cookie\|cookieConsent' --include='*.js' --include='*.ts' --include='*.html' . && ! grep -rn 'cookieBanner\|cookieConsentBanner\|acceptCookies\|cookiePreferences' .
 ```
 
+## ANDROID-ACCOUNT-DELETION-URL
+
+- Title. Account creation without in app deletion and a data deletion URL
+- Platform. google
+- Guideline or policy. User Data
+- Severity. high
+- What triggers it. Account creation present but no in app delete path and no web data deletion URL.
+- How to fix it. Provide in app account deletion and set a public data deletion URL in the Play Console listing.
+- Detection signals. signUp, createAccount, register
+- Present means handled. deleteAccount, delete_account, account deletion
+
+How to detect.
+
+```bash
+grep -rn 'createAccount\|signUp\|register' --include='*.kt' --include='*.java' . && ! grep -rn 'deleteAccount\|delete_account' .   # also set a data deletion URL in the Play listing
+```
+
+## APPLE-5.1.1-UNNECESSARY-DATA
+
+- Title. Requiring personal data not relevant to core functionality
+- Platform. apple
+- Guideline or policy. 5.1.1
+- Severity. high
+- What triggers it. A registration or onboarding form requires phone number, gender, marital status, date of birth, or home address when it is not essential to the core feature. Relevance is contextual.
+- How to fix it. Make non essential personal fields optional. Require only data directly relevant to the core feature. Source. truongduy2611 unnecessary_data rule.
+- Detection signals. phone, gender, marital, date of birth, birthdate, address
+
+How to detect.
+
+```bash
+grep -rni 'phone\|gender\|marital\|date.of.birth\|birthdate\|address' --include='*.swift' . | grep -i 'required\|validator\|isRequired'
+```
+
 ## APPLE-5.1.1-VAGUE-PURPOSE-STRING
 
 - Title. Generic or empty permission purpose string
@@ -115,23 +180,6 @@ How to detect.
 
 ```bash
 for k in NSCameraUsageDescription NSLocationWhenInUseUsageDescription NSPhotoLibraryUsageDescription NSContactsUsageDescription; do v=$(plutil -extract "$k" raw */Info.plist 2>/dev/null); echo "$k = $v"; done   # flag empty or generic values like 'required'
-```
-
-## APPLE-5.1.2-MISSING-ATT
-
-- Title. Tracking SDK without App Tracking Transparency
-- Platform. apple
-- Guideline or policy. 5.1.2(i)
-- Severity. high
-- What triggers it. A tracking or advertising SDK is present but ATTrackingManager request is not called and NSUserTrackingUsageDescription is absent.
-- How to fix it. Call the ATT prompt before any cross app tracking and add the tracking usage description.
-- Detection signals. AppsFlyer, Adjust, Branch, FacebookSDK, IDFA, ASIdentifierManager
-- Present means handled. ATTrackingManager, NSUserTrackingUsageDescription
-
-How to detect.
-
-```bash
-grep -rn 'AppsFlyer\|Adjust\|FBSDK\|advertisingIdentifier\|ASIdentifierManager' --include='*.swift' . && ! grep -rn 'ATTrackingManager\|NSUserTrackingUsageDescription' .
 ```
 
 ## APPLE-5.1.2-AI-NO-CONSENT-MODAL
@@ -151,6 +199,23 @@ How to detect.
 grep -rni 'api.openai.com\|anthropic\|generativelanguage\|chat/completions' . && ! grep -rni 'consent' .
 ```
 
+## APPLE-5.1.2-MISSING-ATT
+
+- Title. Tracking SDK without App Tracking Transparency
+- Platform. apple
+- Guideline or policy. 5.1.2(i)
+- Severity. high
+- What triggers it. A tracking or advertising SDK is present but ATTrackingManager request is not called and NSUserTrackingUsageDescription is absent.
+- How to fix it. Call the ATT prompt before any cross app tracking and add the tracking usage description.
+- Detection signals. AppsFlyer, Adjust, Branch, FacebookSDK, IDFA, ASIdentifierManager
+- Present means handled. ATTrackingManager, NSUserTrackingUsageDescription
+
+How to detect.
+
+```bash
+grep -rn 'AppsFlyer\|Adjust\|FBSDK\|advertisingIdentifier\|ASIdentifierManager' --include='*.swift' . && ! grep -rn 'ATTrackingManager\|NSUserTrackingUsageDescription' .
+```
+
 ## APPLE-ACCOUNT-DELETION-WEAK
 
 - Title. Account deletion is a mailto or deactivate only flow
@@ -167,21 +232,21 @@ How to detect.
 grep -rn 'deleteAccount\|delete account' --include='*.swift' . && grep -rn 'mailto:\|deactivate' --include='*.swift' .   # deletion must truly delete, not mailto or deactivate
 ```
 
-## ANDROID-ACCOUNT-DELETION-URL
+## APPLE-PRIVACY-NUTRITION-LABELS
 
-- Title. Account creation without in app deletion and a data deletion URL
-- Platform. google
-- Guideline or policy. User Data
+- Title. Missing Privacy Nutrition Labels data type declarations
+- Platform. apple
+- Guideline or policy. 5.1.1
 - Severity. high
-- What triggers it. Account creation present but no in app delete path and no web data deletion URL.
-- How to fix it. Provide in app account deletion and set a public data deletion URL in the Play Console listing.
-- Detection signals. signUp, createAccount, register
-- Present means handled. deleteAccount, delete_account, account deletion
+- What triggers it. Collecting sensitive user data (e.g. email, phone, name, coordinates) but missing the privacyNutritionLabels declaration or proper nutrition disclosure references.
+- How to fix it. Update the app privacy manifest (PrivacyInfo.xcprivacy) with NSPrivacyCollectedDataTypes and complete corresponding Nutrition Labels in App Store Connect.
+- Detection signals. email, phoneNumber, userName, location, coordinates
+- Present means handled. NSPrivacyCollectedDataTypes, privacyNutritionLabels, privacy-nutrition-labels
 
 How to detect.
 
 ```bash
-grep -rn 'createAccount\|signUp\|register' --include='*.kt' --include='*.java' . && ! grep -rn 'deleteAccount\|delete_account' .   # also set a data deletion URL in the Play listing
+grep -rn 'email\|phoneNumber\|userName\|location\|coordinates' --include='*.swift' . && ! grep -rn 'NSPrivacyCollectedDataTypes\|privacyNutritionLabels\|privacy-nutrition-labels' .
 ```
 
 ## BOTH-FINGERPRINTING
@@ -200,35 +265,18 @@ How to detect.
 grep -rni 'fingerprint\|deviceFingerprint\|canvas fingerprint' .
 ```
 
-## APPLE-5.1.1-UNNECESSARY-DATA
+## IONIC-PRIVACY-MANIFEST-MISSING
 
-- Title. Requiring personal data not relevant to core functionality
+- Title. Capacitor/Cordova plugin wrapping a native SDK with no PrivacyInfo.xcprivacy
 - Platform. apple
 - Guideline or policy. 5.1.1
 - Severity. high
-- What triggers it. A registration or onboarding form requires phone number, gender, marital status, date of birth, or home address when it is not essential to the core feature. Relevance is contextual.
-- How to fix it. Make non essential personal fields optional. Require only data directly relevant to the core feature. Source. truongduy2611 unnecessary_data rule.
-- Detection signals. phone, gender, marital, date of birth, birthdate, address
+- What triggers it. Capacitor/Cordova plugins are present and no PrivacyInfo.xcprivacy exists anywhere in the project.
+- How to fix it. Capacitor plugin manifest support is less standardized than Flutter's. Verify each plugin wrapping a native SDK (camera, geolocation, ads) ships PrivacyInfo.xcprivacy, and add the app-level one.
+- Detection signals. @capacitor/, Capacitor.
 
 How to detect.
 
 ```bash
-grep -rni 'phone\|gender\|marital\|date.of.birth\|birthdate\|address' --include='*.swift' . | grep -i 'required\|validator\|isRequired'
-```
-
-## APPLE-PRIVACY-NUTRITION-LABELS
-
-- Title. Missing Privacy Nutrition Labels data type declarations
-- Platform. apple
-- Guideline or policy. 5.1.1
-- Severity. high
-- What triggers it. Collecting sensitive user data (e.g. email, phone, name, coordinates) but missing the privacyNutritionLabels declaration or proper nutrition disclosure references.
-- How to fix it. Update the app privacy manifest (PrivacyInfo.xcprivacy) with NSPrivacyCollectedDataTypes and complete corresponding Nutrition Labels in App Store Connect.
-- Detection signals. email, phoneNumber, userName, location, coordinates
-- Present means handled. NSPrivacyCollectedDataTypes, privacyNutritionLabels, privacy-nutrition-labels
-
-How to detect.
-
-```bash
-grep -rn 'email\|phoneNumber\|userName\|location\|coordinates' --include='*.swift' . && ! grep -rn 'NSPrivacyCollectedDataTypes\|privacyNutritionLabels\|privacy-nutrition-labels' .
+grep -rq '@capacitor/\|Capacitor\.' --include='*.ts' . 2>/dev/null && ! find . -name 'PrivacyInfo.xcprivacy' | grep -q .
 ```


### PR DESCRIPTION
Adds Flutter, React Native/Expo, and Ionic/Capacitor/Cordova detection plus 7 framework-specific rejection checks to a guard that was previously native-only. Fixes a real correctness bug found across two adversarial Codex review passes, Apple-only checks were firing on Android-only build commands and are now command-aware. Fixes a monorepo package.json detection gap and an unrelated config.xml false positive. Downgrades IONIC-4.2-THIN-WRAPPER from critical to high. 26 regression tests, all passing. Remaining gaps are documented honestly in docs/CROSS-PLATFORM-FRAMEWORKS.md, including no Android-side framework checks yet, no Expo CNG modeling, and no NativeScript/Xamarin-MAUI/KMP/Unity/Tauri coverage. Reviewed by Codex across two passes and Qwen across one pass, whose findings were checked and none held up.