### PR TITLE
Set default path for PR draft in monitor-ai-policy.py and update gitignore to ignore draft files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 __pycache__/
 *.pyc
 RELEASE-READINESS-REPORT.md
+docs/*_COMPLIANCE_PR_DRAFT.md
+docs/*_PR_DRAFT.md

--- a/scripts/monitor-ai-policy.py
+++ b/scripts/monitor-ai-policy.py
@@ -491,7 +491,8 @@ def main():
     parser.add_argument(
         "--pr-output",
         type=str,
-        help="Filepath to save the drafted PR (will output to stdout if omitted)",
+        default="docs/AI_COMPLIANCE_PR_DRAFT.md",
+        help="Filepath to save the drafted PR",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Modified scripts/monitor-ai-policy.py to set default --pr-output path to docs/AI_COMPLIANCE_PR_DRAFT.md. Also updated .gitignore to ignore any generated compliance PR drafts to keep the repository working tree clean.

---
*PR created automatically by Jules for task [5612826419277586818](https://jules.google.com/task/5612826419277586818) started by @mjmirza*