### PR TITLE
Improve Apple Developer Requirements Monitor and generate compliance files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 __pycache__/
 *.pyc
 RELEASE-READINESS-REPORT.md
+docs/*_PR_DRAFT.md
+docs/*_COMPLIANCE_PR_DRAFT.md

--- a/docs/APPLE-POLICY-MIGRATION.md
+++ b/docs/APPLE-POLICY-MIGRATION.md
@@ -1,0 +1,82 @@
+<!-- APPLE_POLICY_MONITOR_START -->
+# Apple Developer Requirements Policy Migration & Requirements Report
+
+This report is continuously generated and updated by `scripts/monitor.py` to track compliance areas.
+
+## Monitored Requirements Update Log
+
+### 1. [Privacy Manifests] Upcoming Requirements for Privacy Manifests and Required Reason APIs
+- **Published Date**: Wed, 15 May 2026 10:00:00 GMT
+- **Official Resource**: [https://mock.invalid/apple-news/privacy-requirements](https://mock.invalid/apple-news/privacy-requirements)
+- **Description**: Mandatory privacy manifest requirement (PrivacyInfo.xcprivacy) for third-party SDKs and Required Reason APIs.
+
+### 2. [Required Reason APIs] Upcoming Requirements for Privacy Manifests and Required Reason APIs
+- **Published Date**: Wed, 15 May 2026 10:00:00 GMT
+- **Official Resource**: [https://mock.invalid/apple-news/privacy-requirements](https://mock.invalid/apple-news/privacy-requirements)
+- **Description**: Stricter declaration rules for accessing specific Apple system APIs (UserDefaults, systemUptime, system boot time, file timestamps).
+
+### 3. [In-App Purchase policies] Updates to In-App Purchase Policies and Alternative Payment Options
+- **Published Date**: Mon, 01 Jun 2026 09:00:00 GMT
+- **Official Resource**: [https://mock.invalid/apple-news/iap-updates](https://mock.invalid/apple-news/iap-updates)
+- **Description**: App Store rules around StoreKit digital purchases, billing, pricing, and subscriptions.
+
+### 4. [Alternative payment regulations] Updates to In-App Purchase Policies and Alternative Payment Options
+- **Published Date**: Mon, 01 Jun 2026 09:00:00 GMT
+- **Official Resource**: [https://mock.invalid/apple-news/iap-updates](https://mock.invalid/apple-news/iap-updates)
+- **Description**: Permitted exceptions and requirements for offering third-party payment links (region-gated).
+
+### 5. [App Store Review Guidelines] App Store Review Guidelines and 4.3 Saturated Categories Update
+- **Published Date**: Tue, 09 Jun 2026 14:00:00 GMT
+- **Official Resource**: [https://mock.invalid/apple-news/review-guidelines-update](https://mock.invalid/apple-news/review-guidelines-update)
+- **Description**: Changes to the general App Store Review Guidelines. All submitted builds are subjected to these guidelines.
+
+### 6. [SDK requirements] Xcode 26 and Minimum iOS SDK Requirements for Submission
+- **Published Date**: Mon, 03 Feb 2026 08:00:00 GMT
+- **Official Resource**: [https://developer.apple.com/news/upcoming-requirements/?id=xcode-26](https://developer.apple.com/news/upcoming-requirements/?id=xcode-26)
+- **Description**: Requirements for bundled third-party SDKs, including security audits, size limits, and privacy manifests.
+
+### 7. [Minimum SDK versions] Xcode 26 and Minimum iOS SDK Requirements for Submission
+- **Published Date**: Mon, 03 Feb 2026 08:00:00 GMT
+- **Official Resource**: [https://developer.apple.com/news/upcoming-requirements/?id=xcode-26](https://developer.apple.com/news/upcoming-requirements/?id=xcode-26)
+- **Description**: Annual minimum deployment target or target SDK version updates enforced by stores.
+
+## Automated Migration Recommendations & Implementation Tasks
+
+### Tasks for Privacy Manifests
+- **Regulatory Impact**: High priority. Publishing gates require action.
+- [ ] **Task**: Audit third-party SDKs for presence of their signed PrivacyInfo.xcprivacy.
+- [ ] **Task**: Generate or update a root PrivacyInfo.xcprivacy with correct tracking domains and data collection declarations.
+
+### Tasks for Required Reason APIs
+- **Regulatory Impact**: High priority. Publishing gates require action.
+- [ ] **Task**: Identify any use of file timestamps, system boot time, disk space, active keyboard, or user defaults.
+- [ ] **Task**: Declare valid reason codes in PrivacyInfo.xcprivacy under NSPrivacyAccessedAPITypes.
+
+### Tasks for In-App Purchase policies
+- **Regulatory Impact**: High priority. Publishing gates require action.
+- [ ] **Task**: Route all digital goods through StoreKit in-app purchases.
+- [ ] **Task**: Add a prominent Restore Purchases control for non-consumable goods.
+- [ ] **Task**: Verify pricing displays correspond with Apple subscription terms requirements.
+
+### Tasks for Alternative payment regulations
+- **Regulatory Impact**: High priority. Publishing gates require action.
+- [ ] **Task**: Ensure appropriate entitlements are requested and set up for alternative billing.
+- [ ] **Task**: Show mandatory disclosure sheets before redirecting to external web purchase flows.
+
+### Tasks for App Store Review Guidelines
+- **Regulatory Impact**: High priority. Publishing gates require action.
+- [ ] **Task**: Review the updated guidelines section in APPLE.md or the official site.
+- [ ] **Task**: Ensure App Review Notes are updated with working test accounts.
+- [ ] **Task**: Verify the application flows align with the updated guideline numbers.
+
+### Tasks for SDK requirements
+- **Regulatory Impact**: High priority. Publishing gates require action.
+- [ ] **Task**: Perform regular updates on bundled third-party SDKs.
+- [ ] **Task**: Ensure each third-party SDK has its signed privacy manifest file.
+
+### Tasks for Minimum SDK versions
+- **Regulatory Impact**: High priority. Publishing gates require action.
+- [ ] **Task**: Update deployment target version to match latest requirements.
+- [ ] **Task**: Build against required platform SDKs (e.g., iOS 26 SDK, Android API 35/36).
+
+<!-- APPLE_POLICY_MONITOR_END -->

--- a/docs/APPLE_COMPLIANCE_PR_DRAFT.md
+++ b/docs/APPLE_COMPLIANCE_PR_DRAFT.md
@@ -1,0 +1,102 @@
+# Compliance Update: Apple Developer Requirements Integration
+
+## 1. Summary
+This comprehensive Pull Request addresses the latest Apple Developer requirements across multiple compliance domains: Privacy Manifests, Required Reason APIs, In-App Purchase policies, Alternative payment regulations, App Store Review Guidelines, SDK requirements, Minimum SDK versions.
+
+## 2. Background
+To ensure continuous distribution on the App Store without submission bottlenecks or review blocks, we must proactively align our application with updated guidelines and APIs.
+- **Privacy Manifests**: Mandatory privacy manifest requirement (PrivacyInfo.xcprivacy) for third-party SDKs and Required Reason APIs.
+- **Required Reason APIs**: Stricter declaration rules for accessing specific Apple system APIs (UserDefaults, systemUptime, system boot time, file timestamps).
+- **In-App Purchase policies**: App Store rules around StoreKit digital purchases, billing, pricing, and subscriptions.
+- **Alternative payment regulations**: Permitted exceptions and requirements for offering third-party payment links (region-gated).
+- **App Store Review Guidelines**: Changes to the general App Store Review Guidelines. All submitted builds are subjected to these guidelines.
+- **SDK requirements**: Requirements for bundled third-party SDKs, including security audits, size limits, and privacy manifests.
+- **Minimum SDK versions**: Annual minimum deployment target or target SDK version updates enforced by stores.
+
+## 3. Regulatory change
+We are applying platform-specific adjustments to satisfy Apple's App Store Review Guidelines, Privacy Manifest mandates, alternative billing permissions, and security requirements.
+
+## 4. Official citations
+- **Privacy Manifests**: "Upcoming Requirements for Privacy Manifests and Required Reason APIs" - [Official News](https://mock.invalid/apple-news/privacy-requirements)
+- **Required Reason APIs**: "Upcoming Requirements for Privacy Manifests and Required Reason APIs" - [Official News](https://mock.invalid/apple-news/privacy-requirements)
+- **In-App Purchase policies**: "Updates to In-App Purchase Policies and Alternative Payment Options" - [Official News](https://mock.invalid/apple-news/iap-updates)
+- **Alternative payment regulations**: "Updates to In-App Purchase Policies and Alternative Payment Options" - [Official News](https://mock.invalid/apple-news/iap-updates)
+- **App Store Review Guidelines**: "App Store Review Guidelines and 4.3 Saturated Categories Update" - [Official News](https://mock.invalid/apple-news/review-guidelines-update)
+- **SDK requirements**: "Xcode 26 and Minimum iOS SDK Requirements for Submission" - [Official News](https://developer.apple.com/news/upcoming-requirements/?id=xcode-26)
+- **Minimum SDK versions**: "Xcode 26 and Minimum iOS SDK Requirements for Submission" - [Official News](https://developer.apple.com/news/upcoming-requirements/?id=xcode-26)
+
+## 5. Affected files
+- *No specific files containing matching category patterns were automatically detected.*
+
+## 6. Risk assessment
+We have evaluated the impact of these changes to avoid compilation or submission-time rejections:
+- **Privacy Manifests** (Critical Impact): Mandatory privacy manifest requirement (PrivacyInfo.xcprivacy) for third-party SDKs and Required Reason APIs.
+- **Required Reason APIs** (Critical Impact): Stricter declaration rules for accessing specific Apple system APIs (UserDefaults, systemUptime, system boot time, file timestamps).
+- **In-App Purchase policies** (Critical Impact): App Store rules around StoreKit digital purchases, billing, pricing, and subscriptions.
+- **Alternative payment regulations** (High Impact): Permitted exceptions and requirements for offering third-party payment links (region-gated).
+- **App Store Review Guidelines** (High Impact): Changes to the general App Store Review Guidelines. All submitted builds are subjected to these guidelines.
+- **SDK requirements** (High Impact): Requirements for bundled third-party SDKs, including security audits, size limits, and privacy manifests.
+- **Minimum SDK versions** (High Impact): Annual minimum deployment target or target SDK version updates enforced by stores.
+
+## 7. Migration steps
+- [Privacy Manifests] Audit third-party SDKs for presence of their signed PrivacyInfo.xcprivacy.
+- [Privacy Manifests] Generate or update a root PrivacyInfo.xcprivacy with correct tracking domains and data collection declarations.
+- [Required Reason APIs] Identify any use of file timestamps, system boot time, disk space, active keyboard, or user defaults.
+- [Required Reason APIs] Declare valid reason codes in PrivacyInfo.xcprivacy under NSPrivacyAccessedAPITypes.
+- [In-App Purchase policies] Route all digital goods through StoreKit in-app purchases.
+- [In-App Purchase policies] Add a prominent Restore Purchases control for non-consumable goods.
+- [In-App Purchase policies] Verify pricing displays correspond with Apple subscription terms requirements.
+- [Alternative payment regulations] Ensure appropriate entitlements are requested and set up for alternative billing.
+- [Alternative payment regulations] Show mandatory disclosure sheets before redirecting to external web purchase flows.
+- [App Store Review Guidelines] Review the updated guidelines section in APPLE.md or the official site.
+- [App Store Review Guidelines] Ensure App Review Notes are updated with working test accounts.
+- [App Store Review Guidelines] Verify the application flows align with the updated guideline numbers.
+- [SDK requirements] Perform regular updates on bundled third-party SDKs.
+- [SDK requirements] Ensure each third-party SDK has its signed privacy manifest file.
+- [Minimum SDK versions] Update deployment target version to match latest requirements.
+- [Minimum SDK versions] Build against required platform SDKs (e.g., iOS 26 SDK, Android API 35/36).
+
+## 8. Backward compatibility
+All updates maintain compatibility across supported OS deployment targets. Legacy platforms remain functional via compile-time gates and API capability checks.
+
+## 9. Implementation checklist
+- [ ] Audit third-party SDKs for presence of their signed PrivacyInfo.xcprivacy.
+- [ ] Generate or update a root PrivacyInfo.xcprivacy with correct tracking domains and data collection declarations.
+- [ ] Identify any use of file timestamps, system boot time, disk space, active keyboard, or user defaults.
+- [ ] Declare valid reason codes in PrivacyInfo.xcprivacy under NSPrivacyAccessedAPITypes.
+- [ ] Route all digital goods through StoreKit in-app purchases.
+- [ ] Add a prominent Restore Purchases control for non-consumable goods.
+- [ ] Verify pricing displays correspond with Apple subscription terms requirements.
+- [ ] Ensure appropriate entitlements are requested and set up for alternative billing.
+- [ ] Show mandatory disclosure sheets before redirecting to external web purchase flows.
+- [ ] Review the updated guidelines section in APPLE.md or the official site.
+- [ ] Ensure App Review Notes are updated with working test accounts.
+- [ ] Verify the application flows align with the updated guideline numbers.
+- [ ] Perform regular updates on bundled third-party SDKs.
+- [ ] Ensure each third-party SDK has its signed privacy manifest file.
+- [ ] Update deployment target version to match latest requirements.
+- [ ] Build against required platform SDKs (e.g., iOS 26 SDK, Android API 35/36).
+
+## 10. Testing checklist
+- [ ] Run the pre-submission compliance guard: `bash agent-os/hooks/app-store-compliance-guard.sh .`
+- [ ] Verify on physical iOS/iPadOS/macOS devices/simulators that the updated flows function correctly.
+- [ ] Double-check that no unexpected runtime crashes or warnings are logged during compilation.
+
+## 11. Documentation checklist
+- [ ] Update internal developer documentation with these platform requirements.
+- [ ] Verify the App Store Review Notes are up-to-date in App Store Connect with working test accounts.
+
+## 12. Compliance impact
+Implementing these updates protects our App Store developer program standing, reducing submission rejection risk to Low and securing our active distribution status.
+
+## 13. Breaking changes
+There are no breaking changes or structural API deprecations. However, missing these declarations is considered a blocker for submitting updates.
+
+## 14. Review checklist
+- [ ] All required App Store metadata keys and configuration properties are in place.
+- [ ] No prohibited private APIs or un-declared Required Reason APIs are referenced.
+- [ ] Code builds cleanly in Xcode.
+
+## 15. Approver recommendations
+- **Lead Mobile Developer / Architect** (for codebase verification)
+- **App Delivery Manager** (for release timeline alignment)

--- a/scripts/monitor-apple-test.sh
+++ b/scripts/monitor-apple-test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Test suite for Apple Developer Requirements Monitor (scripts/monitor.py)
+# Verifies mock news/simulation input, codebase scanning, file generation,
+# presence of exactly 15 required compliance sections in the PR draft,
+# and adherence to the strict emoji-free policy.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS+1)); printf 'PASS  %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf 'FAIL  %s\n' "$1"; }
+
+OUT_DOCS="/tmp/test_apple_migration.md"
+OUT_PR="/tmp/test_apple_pr.md"
+
+cleanup() {
+  rm -f "$OUT_DOCS" "$OUT_PR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "== Running Apple Developer Requirements Monitor Test Suite =="
+
+# 1. Execute monitor.py in simulation mode to generate documentation and PR drafts
+python3 scripts/monitor.py --simulate "Privacy Manifests" --output-docs "$OUT_DOCS" --pr-output "$OUT_PR" > /tmp/apple_monitor_run.log 2>&1
+RC=$?
+
+if [ "$RC" -ne 0 ]; then
+  bad "monitor.py failed to execute. Log:"
+  cat /tmp/apple_monitor_run.log
+  exit 1
+fi
+ok "monitor.py executed successfully in simulation mode"
+
+# 2. Check that the documentation migration report was generated correctly
+if [ -f "$OUT_DOCS" ]; then
+  ok "Documentation output file created at $OUT_DOCS"
+  if grep -q "Privacy Manifests" "$OUT_DOCS"; then
+    ok "Documentation contains details of matched Privacy Manifests update"
+  else
+    bad "Documentation is missing matched details"
+  fi
+else
+  bad "Documentation file was not created"
+fi
+
+# 3. Check that the PR draft was generated and contains exactly 15 required sections
+if [ -f "$OUT_PR" ]; then
+  ok "PR Draft output file created at $OUT_PR"
+
+  declare -a SECTIONS=(
+    "Summary"
+    "Background"
+    "Regulatory change"
+    "Official citations"
+    "Affected files"
+    "Risk assessment"
+    "Migration steps"
+    "Backward compatibility"
+    "Implementation checklist"
+    "Testing checklist"
+    "Documentation checklist"
+    "Compliance impact"
+    "Breaking changes"
+    "Review checklist"
+    "Approver recommendations"
+  )
+
+  MISSING=0
+  for idx in "${!SECTIONS[@]}"; do
+    sec_num=$((idx + 1))
+    sec_name="${SECTIONS[$idx]}"
+    if grep -q "## ${sec_num}\. ${sec_name}" "$OUT_PR"; then
+      true
+    else
+      echo "  Missing PR section: ## ${sec_num}. ${sec_name}"
+      MISSING=$((MISSING + 1))
+    fi
+  done
+
+  if [ "$MISSING" -eq 0 ]; then
+    ok "PR Draft contains exactly the 15 required compliance sections"
+  else
+    bad "PR Draft is missing $MISSING of the 15 required compliance sections"
+  fi
+else
+  bad "PR Draft file was not created"
+fi
+
+# 4. Verify strict emoji-free policy on output files
+EMOJI_CHECK=$(python3 -c "
+import sys
+for path in ['$OUT_DOCS', '$OUT_PR']:
+    with open(path, encoding='utf-8') as f:
+        text = f.read()
+        emojis = [c for c in text if 0x1F300 <= ord(c) <= 0x1F9FF or 0x2600 <= ord(c) <= 0x27BF]
+        if emojis:
+            print('Found emojis:', emojis)
+            sys.exit(1)
+print('No emojis found')
+")
+
+if [ "$EMOJI_CHECK" != "No emojis found" ]; then
+  bad "Emojis detected in generated output files!"
+  exit 1
+fi
+ok "All generated Apple compliance files are 100% emoji-free"
+
+# 5. Verify that running monitor.py with --json has suppressed console messages but generated files
+rm -f "$OUT_DOCS" "$OUT_PR"
+JSON_OUT=$(python3 scripts/monitor.py --simulate "Required Reason APIs" --output-docs "$OUT_DOCS" --pr-output "$OUT_PR" --json 2>&1)
+
+if echo "$JSON_OUT" | python3 -c "import sys, json; json.load(sys.stdin)" 2>/dev/null; then
+  ok "Output is valid JSON when running with --json"
+else
+  bad "Output is not valid JSON or contains extra log messages when running with --json. Output: $JSON_OUT"
+fi
+
+if [ -f "$OUT_DOCS" ] && [ -f "$OUT_PR" ]; then
+  ok "Documentation and PR draft were successfully generated in the background when running with --json"
+else
+  bad "Files were not generated when running with --json"
+fi
+
+echo ""
+echo "Apple Monitor test suite: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -891,50 +891,50 @@ def generate_pull_request(track_name, affected_files, item_title):
     desc_lines = [
         f"# Compliance Update: {track_name}",
         "",
-        "## Summary",
+        "## 1. Summary",
         f"This Pull Request addresses the latest compliance requirements for **{track_name}**, "
         f'triggered by the developer update: *"{item_title}"*.',
         "",
-        "## Background",
+        "## 2. Background",
         bg_context,
         "",
-        "## Regulatory change",
+        "## 3. Regulatory change",
         reg_change_desc,
         "",
-        "## Official citations",
+        "## 4. Official citations",
         "\n".join(citations),
         "",
-        "## Affected files",
+        "## 5. Affected files",
         affected_files_content,
         "",
-        "## Risk assessment",
+        "## 6. Risk assessment",
         risk_desc,
         "",
-        "## Migration steps",
+        "## 7. Migration steps",
         "\n".join(migration_steps_lines),
         "",
-        "## Backward compatibility",
+        "## 8. Backward compatibility",
         bk_compat,
         "",
-        "## Implementation checklist",
+        "## 9. Implementation checklist",
         "\n".join(impl_checklist),
         "",
-        "## Testing checklist",
+        "## 10. Testing checklist",
         "\n".join(test_checklist),
         "",
-        "## Documentation checklist",
+        "## 11. Documentation checklist",
         "\n".join(doc_checklist),
         "",
-        "## Compliance impact",
+        "## 12. Compliance impact",
         compliance_impact_desc,
         "",
-        "## Breaking changes",
+        "## 13. Breaking changes",
         breaking_changes_desc,
         "",
-        "## Review checklist",
+        "## 14. Review checklist",
         "\n".join(review_checklist),
         "",
-        "## Approver recommendations",
+        "## 15. Approver recommendations",
         approver_rec,
         "",
         "---",
@@ -1068,6 +1068,227 @@ def run_monitor(
     return report_items, processed_tracks
 
 
+def generate_blank_pr_draft():
+    sections = [
+        "## 1. Summary",
+        "No new or simulated Apple Developer requirement updates detected. The codebase is currently up to date.",
+        "",
+        "## 2. Background",
+        "Regular monitoring of Apple's App Store Review Guidelines and Developer Program License Agreement is maintained to prevent release disruption.",
+        "",
+        "## 3. Regulatory change",
+        "No active regulatory or policy modifications have been identified in this cycle.",
+        "",
+        "## 4. Official citations",
+        "- Apple Developer News & Updates: [Apple Developer News](https://developer.apple.com/news/)",
+        "",
+        "## 5. Affected files",
+        "- *No files affected.*",
+        "",
+        "## 6. Risk assessment",
+        "Risk level: Low. No outstanding platform compliance updates are required.",
+        "",
+        "## 7. Migration steps",
+        "No migration steps are currently necessary.",
+        "",
+        "## 8. Backward compatibility",
+        "All interfaces and metadata configurations remain backward compatible.",
+        "",
+        "## 9. Implementation checklist",
+        "- [ ] No actions required.",
+        "",
+        "## 10. Testing checklist",
+        "- [ ] Run existing compliance automated test suite to ensure no regression.",
+        "",
+        "## 11. Documentation checklist",
+        "- [ ] Verify that privacy policy and support URLs remain active.",
+        "",
+        "## 12. Compliance impact",
+        "The application remains fully compliant with the latest guidelines.",
+        "",
+        "## 13. Breaking changes",
+        "None.",
+        "",
+        "## 14. Review checklist",
+        "- [ ] Confirm that all compliance validations pass cleanly.",
+        "",
+        "## 15. Approver recommendations",
+        "Recommended for routine approval.",
+    ]
+    return "# Compliance Update: Apple Developer Requirements\n\n" + "\n".join(sections)
+
+
+def generate_unified_pr_draft(report_items):
+    tracks = [item["track"] for item in report_items]
+
+    citations = []
+    affected_files = set()
+    risks = []
+    migration_steps = []
+    impl_checklist = []
+    background_notes = []
+
+    for item in report_items:
+        track = item["track"]
+        title = item["announcement_title"]
+        link = item["announcement_link"]
+        meta = TRACK_METADATA.get(track, {})
+
+        citations.append(f"- **{track}**: \"{title}\" - [Official News]({link})")
+
+        for f in item["affected_files"]:
+            affected_files.add(f)
+
+        risks.append(f"- **{track}** ({item['severity_impact']} Impact): {item['repository_impact']}")
+
+        for step in item["migration_tasks"]:
+            migration_steps.append(f"- [{track}] {step}")
+            impl_checklist.append(f"- [ ] {step}")
+
+        background_notes.append(f"- **{track}**: {meta.get('impact_desc', '')}")
+
+    test_checklist = [
+        "- [ ] Run the pre-submission compliance guard: `bash agent-os/hooks/app-store-compliance-guard.sh .`",
+        "- [ ] Verify on physical iOS/iPadOS/macOS devices/simulators that the updated flows function correctly.",
+        "- [ ] Double-check that no unexpected runtime crashes or warnings are logged during compilation."
+    ]
+
+    doc_checklist = [
+        "- [ ] Update internal developer documentation with these platform requirements.",
+        "- [ ] Verify the App Store Review Notes are up-to-date in App Store Connect with working test accounts."
+    ]
+
+    affected_files_str = ""
+    if affected_files:
+        affected_files_str = "\n".join(f"- `{f}`" for f in sorted(list(affected_files)))
+    else:
+        affected_files_str = "- *No specific files containing matching category patterns were automatically detected.*"
+
+    sections = [
+        "# Compliance Update: Apple Developer Requirements Integration",
+        "",
+        "## 1. Summary",
+        f"This comprehensive Pull Request addresses the latest Apple Developer requirements across multiple compliance domains: {', '.join(tracks)}.",
+        "",
+        "## 2. Background",
+        "To ensure continuous distribution on the App Store without submission bottlenecks or review blocks, we must proactively align our application with updated guidelines and APIs.",
+        "\n".join(background_notes),
+        "",
+        "## 3. Regulatory change",
+        "We are applying platform-specific adjustments to satisfy Apple's App Store Review Guidelines, Privacy Manifest mandates, alternative billing permissions, and security requirements.",
+        "",
+        "## 4. Official citations",
+        "\n".join(citations),
+        "",
+        "## 5. Affected files",
+        affected_files_str,
+        "",
+        "## 6. Risk assessment",
+        "We have evaluated the impact of these changes to avoid compilation or submission-time rejections:",
+        "\n".join(risks),
+        "",
+        "## 7. Migration steps",
+        "\n".join(migration_steps),
+        "",
+        "## 8. Backward compatibility",
+        "All updates maintain compatibility across supported OS deployment targets. Legacy platforms remain functional via compile-time gates and API capability checks.",
+        "",
+        "## 9. Implementation checklist",
+        "\n".join(impl_checklist),
+        "",
+        "## 10. Testing checklist",
+        "\n".join(test_checklist),
+        "",
+        "## 11. Documentation checklist",
+        "\n".join(doc_checklist),
+        "",
+        "## 12. Compliance impact",
+        "Implementing these updates protects our App Store developer program standing, reducing submission rejection risk to Low and securing our active distribution status.",
+        "",
+        "## 13. Breaking changes",
+        "There are no breaking changes or structural API deprecations. However, missing these declarations is considered a blocker for submitting updates.",
+        "",
+        "## 14. Review checklist",
+        "- [ ] All required App Store metadata keys and configuration properties are in place.",
+        "- [ ] No prohibited private APIs or un-declared Required Reason APIs are referenced.",
+        "- [ ] Code builds cleanly in Xcode.",
+        "",
+        "## 15. Approver recommendations",
+        "- **Lead Mobile Developer / Architect** (for codebase verification)",
+        "- **App Delivery Manager** (for release timeline alignment)"
+    ]
+
+    return "\n".join(sections)
+
+
+def write_compliance_files(report_items, output_docs_path, pr_output_path, verbose=False, is_json=False):
+    for path in [output_docs_path, pr_output_path]:
+        if path:
+            dir_name = os.path.dirname(path)
+            if dir_name and not os.path.exists(dir_name):
+                os.makedirs(dir_name, exist_ok=True)
+
+    doc_lines = [
+        "<!-- APPLE_POLICY_MONITOR_START -->",
+        "# Apple Developer Requirements Policy Migration & Requirements Report",
+        "",
+        "This report is continuously generated and updated by `scripts/monitor.py` to track compliance areas.",
+        "",
+        "## Monitored Requirements Update Log",
+        "",
+    ]
+
+    if not report_items:
+        doc_lines.append("No active or simulated developer requirement updates found matching Apple developer requirements tracks.")
+    else:
+        for idx, item in enumerate(report_items, 1):
+            doc_lines.append(f"### {idx}. [{item['track']}] {item['announcement_title']}")
+            doc_lines.append(f"- **Published Date**: {item['announcement_pubDate']}")
+            doc_lines.append(f"- **Official Resource**: [{item['announcement_link']}]({item['announcement_link']})")
+            doc_lines.append(f"- **Description**: {item['repository_impact']}")
+            doc_lines.append("")
+
+        doc_lines.append("## Automated Migration Recommendations & Implementation Tasks")
+        doc_lines.append("")
+        for item in report_items:
+            track = item["track"]
+            doc_lines.append(f"### Tasks for {track}")
+            doc_lines.append("- **Regulatory Impact**: High priority. Publishing gates require action.")
+            for step in item["migration_tasks"]:
+                doc_lines.append(f"- [ ] **Task**: {step}")
+            doc_lines.append("")
+
+    doc_lines.append("<!-- APPLE_POLICY_MONITOR_END -->")
+
+    if output_docs_path:
+        try:
+            with open(output_docs_path, "w", encoding="utf-8") as f:
+                f.write("\n".join(doc_lines))
+            if verbose and not is_json:
+                print(f"[*] Apple policy migration report successfully updated at: {output_docs_path}")
+        except Exception as e:
+            if verbose or not is_json:
+                print(f"[!] Error writing documentation report to {output_docs_path}: {e}")
+
+    if pr_output_path:
+        pr_content = ""
+        if not report_items:
+            pr_content = generate_blank_pr_draft()
+        elif len(report_items) == 1:
+            pr_content = report_items[0]["proposed_pull_request"]["description"]
+        else:
+            pr_content = generate_unified_pr_draft(report_items)
+
+        try:
+            with open(pr_output_path, "w", encoding="utf-8") as f:
+                f.write(pr_content)
+            if verbose and not is_json:
+                print(f"[*] Apple compliance PR draft successfully written to: {pr_output_path}")
+        except Exception as e:
+            if verbose or not is_json:
+                print(f"[!] Error writing PR draft to {pr_output_path}: {e}")
+
+
 def print_text_report(report_items, project_path):
     print("=" * 80)
     print("                  APPLE DEVELOPER REQUIREMENTS MONITOR REPORT")
@@ -1141,6 +1362,16 @@ def main():
         action="store_true",
         help="Print verbose execution and scanning logs",
     )
+    parser.add_argument(
+        "--output-docs",
+        default="docs/APPLE-POLICY-MIGRATION.md",
+        help="Filepath to write migration tasks and logs",
+    )
+    parser.add_argument(
+        "--pr-output",
+        default="docs/APPLE_COMPLIANCE_PR_DRAFT.md",
+        help="Filepath to save the drafted PR",
+    )
 
     args = parser.parse_args()
 
@@ -1150,6 +1381,14 @@ def main():
         use_mock=args.mock,
         custom_news_file=args.news_file,
         verbose=args.verbose,
+    )
+
+    write_compliance_files(
+        report_items=report_items,
+        output_docs_path=args.output_docs,
+        pr_output_path=args.pr_output,
+        verbose=args.verbose,
+        is_json=args.json
     )
 
     if args.json:


### PR DESCRIPTION
This update enhances the Apple Developer Requirements Monitor utility (`scripts/monitor.py`) to support physical file generation for both migration reports (`docs/APPLE-POLICY-MIGRATION.md`) and comprehensive 15-section, emoji-free Pull Request drafts (`docs/APPLE_COMPLIANCE_PR_DRAFT.md`). A dedicated compliance test suite `scripts/monitor-apple-test.sh` is introduced to verify this new functionality. All existing and new tests pass cleanly.

---
*PR created automatically by Jules for task [8685833630627171114](https://jules.google.com/task/8685833630627171114) started by @mjmirza*