### PR TITLE
Implement default output path and test coverage for AI compliance PR drafts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ node_modules/
 __pycache__/
 *.pyc
 RELEASE-READINESS-REPORT.md
+
+# Compliance PR drafts
+docs/*_PR_DRAFT.md
+docs/*_COMPLIANCE_PR_DRAFT.md

--- a/scripts/monitor-ai-policy-test.sh
+++ b/scripts/monitor-ai-policy-test.sh
@@ -17,7 +17,7 @@ OUT_PR="/tmp/test_ai_pr.md"
 
 # Cleanup files first
 cleanup() {
-  rm -f "$MOCK_JSON" "$OUT_DOCS" "$OUT_PR" 2>/dev/null || true
+  rm -f "$MOCK_JSON" "$OUT_DOCS" "$OUT_PR" "docs/AI_COMPLIANCE_PR_DRAFT.md" 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -135,6 +135,74 @@ else
   bad "PR Draft file was not created"
 fi
 
+# 6. Assert that the default --pr-output behaves correctly
+echo "Testing default --pr-output behavior..."
+rm -f "docs/AI_COMPLIANCE_PR_DRAFT.md" 2>/dev/null || true
+
+python3 scripts/monitor-ai-policy.py --mock "$MOCK_JSON" --dir . --output-docs "$OUT_DOCS" > /tmp/monitor_run_default.log 2>&1
+RC=$?
+
+if [ "$RC" -ne 0 ]; then
+  bad "monitor-ai-policy.py with default --pr-output failed with exit code $RC. Output:"
+  cat /tmp/monitor_run_default.log
+  exit 1
+fi
+
+if [ -f "docs/AI_COMPLIANCE_PR_DRAFT.md" ]; then
+  ok "Default PR Draft output file created at docs/AI_COMPLIANCE_PR_DRAFT.md"
+
+  # Check 15 sections on default PR draft
+  MISSING=0
+  for idx in "${!SECTIONS[@]}"; do
+    sec_num=$((idx + 1))
+    sec_name="${SECTIONS[$idx]}"
+    if grep -q "## ${sec_num}\. ${sec_name}" "docs/AI_COMPLIANCE_PR_DRAFT.md"; then
+      true
+    else
+      echo "  Missing PR section in default draft: ## ${sec_num}. ${sec_name}"
+      MISSING=$((MISSING + 1))
+    fi
+  done
+
+  if [ "$MISSING" -eq 0 ]; then
+    ok "Default PR Draft contains exactly the 15 required compliance sections"
+  else
+    bad "Default PR Draft is missing $MISSING of the 15 required compliance sections"
+  fi
+else
+  bad "Default PR Draft file was not created"
+fi
+
+# 7. Assert no emojis are present in outputs or scripts
+echo "Checking for emojis in scripts and generated files..."
+has_emojis() {
+  python3 -c "
+import sys
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
+    text = f.read()
+import re
+emojis = re.findall(r'[\U00010000-\U0010ffff]', text)
+if emojis:
+    print('Found emojis in', sys.argv[1], ':', emojis)
+    sys.exit(1)
+sys.exit(0)
+" "$1"
+}
+
+if has_emojis "scripts/monitor-ai-policy.py" && \
+   has_emojis "scripts/monitor-ai-policy-test.sh" && \
+   has_emojis "$OUT_DOCS" && \
+   has_emojis "$OUT_PR" && \
+   has_emojis "docs/AI_COMPLIANCE_PR_DRAFT.md"; then
+  ok "All scripts and generated markdown files are 100% emoji-free"
+else
+  bad "Emoji check failed: high-unicode emojis or symbols detected"
+fi
+
 echo ""
 echo "AI Policy Monitor test suite: $PASS passed, $FAIL failed"
-[ "$FAIL" -eq 0 ]
+if [ "$FAIL" -eq 0 ]; then
+  exit 0
+else
+  exit 1
+fi

--- a/scripts/monitor-ai-policy.py
+++ b/scripts/monitor-ai-policy.py
@@ -491,7 +491,8 @@ def main():
     parser.add_argument(
         "--pr-output",
         type=str,
-        help="Filepath to save the drafted PR (will output to stdout if omitted)",
+        default="docs/AI_COMPLIANCE_PR_DRAFT.md",
+        help="Filepath to save the drafted PR",
     )
 
     args = parser.parse_args()
@@ -548,6 +549,7 @@ def main():
 
     if args.pr_output:
         try:
+            os.makedirs(os.path.dirname(args.pr_output) or ".", exist_ok=True)
             with open(args.pr_output, "w", encoding="utf-8") as f:
                 f.write(pr_draft)
             print(f"PR Draft successfully written to: {args.pr_output}")


### PR DESCRIPTION
This change updates the platform-specific AI policy compliance monitoring utility to default to drafting the 15-section Pull Request inside 'docs/AI_COMPLIANCE_PR_DRAFT.md'. Additionally, it adds exhaustive assertions to the test suite to verify default generation behavior and enforce strict emoji-free controls on the scripts and generated files.

---
*PR created automatically by Jules for task [2418182923774384497](https://jules.google.com/task/2418182923774384497) started by @mjmirza*