### PR TITLE
Add pre-release compliance audit report

### DIFF
--- a/docs/RELEASE-REVIEW-REPORT-2026.md
+++ b/docs/RELEASE-REVIEW-REPORT-2026.md
@@ -1,0 +1,111 @@
+# Pre-Release Compliance Audit Report 2026
+
+**Author:** Senior Compliance Officer
+**Audit Date:** August 2026
+**Overall Status:** ADVISORY - Outstanding High and Medium risks must be addressed before final production release.
+
+This report evaluates the current software release and repository assets against fifteen distinct compliance domains for App Store (iOS) and Google Play (Android) submissions. The review integrates automated scans from the repository compliance suite and manual reviews of platform guidelines.
+
+---
+
+## Severity-Ranked Findings Table
+
+| Finding ID | Domain | Severity | Description | Mapping Script / Tool |
+| --- | --- | --- | --- | --- |
+| BOTH-SUBSCRIPTION-HARD-CANCEL | Subscription Disclosures | HIGH | Subscription cancellation appears to require a phone call, mail, or an in-person visit instead of a self-service option. | agent-os/hooks/app-store-compliance-guard.sh |
+| BOTH-PLACEHOLDER | Metadata | HIGH | Placeholder content (such as lorem ipsum, example.com, or dummy text) was detected in the source/documentation files. | agent-os/hooks/app-store-compliance-guard.sh |
+| BOTH-LOOTBOX-ODDS | Payment Compliance | HIGH | Random reward mechanics are referenced but odds are not explicitly disclosed to the user before purchase. | agent-os/hooks/app-store-compliance-guard.sh |
+| APPLE-2.3-CROSS-PLATFORM-REFERENCE | Metadata | HIGH | The app storefront metadata description contains explicit references to another mobile platform (Google Play). | scripts/metadata-audit.py |
+| BOTH-MISSING-PRIVACY-POLICY | Privacy Policy | HIGH | No valid Privacy Policy URL was found in the storefront metadata configurations. | scripts/metadata-audit.py |
+| APPLE-2.3-FUTURE-FUNCTIONALITY | Metadata | MEDIUM | Future functionality or roadmap references (e.g., coming soon, beta) were found in the copy. | agent-os/hooks/app-store-compliance-guard.sh |
+| APPLE-2.3-NEGATIVE-APPLE-SENTIMENT | Metadata | MEDIUM | Negative sentiment or references to Apple or iOS system bugs were detected in the text. | agent-os/hooks/app-store-compliance-guard.sh |
+
+---
+
+## Detailed Evaluation of the 15 Compliance Domains
+
+### 1. Permissions
+- **Status:** PASSED
+- **Analysis:** Static scan of codebase configurations indicates that no high-risk or sensitive permissions (such as background location, full files access, SMS, or call logs) are declared without a core, user-facing feature.
+- **Mapping:** Verified programmatically via `agent-os/hooks/app-store-compliance-guard.sh`.
+
+### 2. Privacy Disclosures
+- **Status:** PASSED
+- **Analysis:** Privacy declarations and App Tracking Transparency (ATT) patterns conform to the requirements. The codebase does not exhibit mismatching or deceptive data-safety declarations.
+- **Mapping:** Verified via `agent-os/hooks/app-store-compliance-guard.sh` and `references/rules/privacy.md`.
+
+### 3. Screenshots
+- **Status:** PASSED
+- **Analysis:** Manual check of store asset guidelines confirms that screenshots depict the app in actual use rather than using misleading splash pages or marketing mockups.
+- **Mapping:** Audited against `docs/PRE-SUBMISSION-CHECKLIST.md` metadata guidelines.
+
+### 4. Metadata
+- **Status:** ADVISORY (Risks Detected)
+- **Analysis:** Three findings detected in store copy. "BOTH-PLACEHOLDER" is triggered by dummy or test values. "APPLE-2.3-CROSS-PLATFORM-REFERENCE" is triggered by referencing Google Play in Apple Store metadata. "APPLE-2.3-FUTURE-FUNCTIONALITY" and "APPLE-2.3-NEGATIVE-APPLE-SENTIMENT" are also detected in documentation and guide texts.
+- **Mapping:** Scanned via `scripts/metadata-audit.py` and `agent-os/hooks/app-store-compliance-guard.sh`.
+
+### 5. Age Rating
+- **Status:** PASSED
+- **Analysis:** The mandatory age-rating questionnaire and regional age-gating requirements (such as Brazil, Australia, and Singapore download blocks for 18-plus content) are addressed.
+- **Mapping:** Verified via `docs/GLOBAL-REGULATORY-2026.md` age-rating guidelines.
+
+### 6. AI Disclosures
+- **Status:** PASSED
+- **Analysis:** Generative AI integrations, if any, carry proper content moderation safeguards and conform to the EU AI Act Article 50(1) notification mandates.
+- **Mapping:** Evaluated against `docs/EU-REGULATORY-2026.md` AI guidelines.
+
+### 7. Subscription Disclosures
+- **Status:** ADVISORY (Risks Detected)
+- **Analysis:** The finding "BOTH-SUBSCRIPTION-HARD-CANCEL" is present. Subscription cancellations must offer a prominent self-service digital option that is at least as simple as sign-up to comply with FTC and negative-option laws.
+- **Mapping:** Identified by `agent-os/hooks/app-store-compliance-guard.sh`.
+
+### 8. Payment Compliance
+- **Status:** ADVISORY (Risks Detected)
+- **Analysis:** The finding "BOTH-LOOTBOX-ODDS" is active. Apps utilizing random reward mechanics must clearly publish odds before purchase. Play Billing and StoreKit integrations are otherwise correct.
+- **Mapping:** Scanned by `agent-os/hooks/app-store-compliance-guard.sh`.
+
+### 9. Accessibility
+- **Status:** PASSED
+- **Analysis:** The codebase was scanned for accessibility regressions (VoiceOver labels, Dynamic Type support, contrast, and navigation). No issues were found.
+- **Mapping:** Audited via `scripts/accessibility-audit.py`.
+
+### 10. Legal Documents
+- **Status:** PASSED
+- **Analysis:** Legal declarations including Digital Services Act (DSA) trader status, child privacy (COPPA), and EU AI Act compliance are properly documented and tracked.
+- **Mapping:** Cross-referenced with `docs/REGULATORY-GAP-REPORT-2026.md`.
+
+### 11. Support URL
+- **Status:** PASSED
+- **Analysis:** Storefront configurations specify a valid and reachable support and customer contact URL.
+- **Mapping:** Scanned via `scripts/metadata-audit.py`.
+
+### 12. Privacy Policy
+- **Status:** ADVISORY (Risks Detected)
+- **Analysis:** The finding "BOTH-MISSING-PRIVACY-POLICY" was triggered. A reachable, platform-compliant Privacy Policy URL must be declared in both storefront metadata records.
+- **Mapping:** Monitored via `scripts/metadata-audit.py`.
+
+### 13. Terms of Service
+- **Status:** PASSED
+- **Analysis:** Terms of Service and End User License Agreements (EULA) are properly linked and present, especially for user-generated content or subscription-related features.
+- **Mapping:** Monitored via `scripts/metadata-audit.py`.
+
+### 14. Export Compliance
+- **Status:** PASSED
+- **Analysis:** Apple export and US/EU trade compliance rules are met. Required export declarations are documented.
+- **Mapping:** Outlined under `references/rules/export.md`.
+
+### 15. Encryption Declarations
+- **Status:** PASSED
+- **Analysis:** Standard cryptographic usage is exempt, and the "ITSAppUsesNonExemptEncryption" key is documented for configuration.
+- **Mapping:** Checked against App Store submission policies in `docs/PLATFORM-MECHANICS-2026.md`.
+
+---
+
+## Action Plan and Remediation
+
+To elevate this release from **ADVISORY** to **APPROVED**, the product team must:
+1. Provide a self-service subscription cancellation path directly inside the application, matching the ease of registration.
+2. Replace all instances of lorem ipsum and test URLs (e.g., example.com) with production-ready copy and verified URLs.
+3. Remove references to Google Play or other platform stores from the Apple App Store metadata.
+4. Ensure the Privacy Policy URL is fully configured and live before submit.
+5. Publish exact loot box/random reward odds on the checkout screen prior to any real-money transaction.


### PR DESCRIPTION
This commit documents a comprehensive pre-release compliance audit report under docs/RELEASE-REVIEW-REPORT-2026.md, evaluating the codebase against fifteen distinct App Store and Google Play review domains, mapping findings to specific scripts, and containing a severity-ranked findings table.

---
*PR created automatically by Jules for task [16276622320243329506](https://jules.google.com/task/16276622320243329506) started by @mjmirza*