### PR TITLE
Add pre-release compliance audit report for App Store and Google Play submissions

### DIFF
--- a/docs/RELEASE-REVIEW-REPORT-2026.md
+++ b/docs/RELEASE-REVIEW-REPORT-2026.md
@@ -1,0 +1,148 @@
+# Release Review Compliance Audit Report
+
+## 1. Executive Summary
+
+This Pre-Release Compliance Audit Report has been prepared from the perspective of the Senior Compliance Officer. It evaluates the repository's source materials, guidelines, checklists, and automated scanning scripts against fifteen distinct App Store and Google Play review domains, mapping findings to specific automation scripts and playbooks.
+
+Since this repository serves as a mobile and regulatory compliance playbook and test suite, several educational examples of typical developer mistakes (e.g., placeholder URLs, hardcoded cancellation reference paths, cross-platform references, and unrated loot boxes) are deliberately present in the documentation files. While the automated scanning scripts flag these as high or medium risk findings, this audit evaluates them as educational false-positives for the repository itself, while confirming that the repository's compliance-enforcement engines function exactly as designed to protect production builds from submission failures.
+
+The overall release status of this repository's compliance playbook is ADVISORY due to the deliberate presence of educational compliance-gap patterns in the reference manuals.
+
+---
+
+## 2. Fifteen Domain Evaluations
+
+### 2.1 Permissions
+- **Verification Scope**: Audit all permissions and usage description strings (purpose strings) to ensure no sensitive declarations (such as location, camera, or contacts) are compiled without a core user-facing feature or a non-generic reason string.
+- **Playbook and Script Mapping**:
+  - Script: `agent-os/hooks/app-store-compliance-guard.sh` (statically scans files for unmapped sensitive permissions and checks for generic purpose strings).
+  - Checklist: `docs/PRE-SUBMISSION-CHECKLIST.md` under "Privacy and data" and "Google Play specific".
+  - Rules Reference: `references/rules/privacy.md` and `references/rules/android.md`.
+- **Compliance Status**: Passed. No sensitive permissions or unmapped usage descriptions are declared in the codebase files of this playbook.
+
+### 2.2 Privacy Disclosures
+- **Verification Scope**: Ensure the app presents appropriate consent modals (such as App Tracking Transparency on iOS) and accurate data safety/nutrition disclosures for user data collection and SDK tracking.
+- **Playbook and Script Mapping**:
+  - Script: `scripts/release-audit.py` (statically scans for pattern IDs such as `APPLE-5.1.2-MISSING-ATT` and `GOOGLE-DATASAFETY-MISMATCH`).
+  - Checklist: `docs/PRE-SUBMISSION-CHECKLIST.md` under "Privacy and data" and "Google Play specific".
+  - Rules Reference: `references/rules/privacy.md` and `docs/MOBILE-PRIVACY-MONITOR-2026.md`.
+- **Compliance Status**: Advisory. The release-audit script flags `BOTH-MISSING-PRIVACY-POLICY` when run on empty metadata directories, which is expected since the playbook does not bundle a live store listing. However, the privacy disclosures rules are fully integrated.
+
+### 2.3 Screenshots
+- **Verification Scope**: Confirm store screenshots represent the actual app in use (not splash or login screens), adhere to character and decoration checks, and reflect current capabilities.
+- **Playbook and Script Mapping**:
+  - Checklist: `docs/PRE-SUBMISSION-CHECKLIST.md` under "Metadata and listing".
+  - Rules Reference: `references/rules/metadata.md`.
+- **Compliance Status**: Passed. No actual storefront screenshots are compiled in this reference repository, but the mandatory verification rules and character limits are fully documented and integrated.
+
+### 2.4 Metadata
+- **Verification Scope**: Check character limits (such as the 30-character limit for Apple App Store names), ALL CAPS, emojis, references to competing platforms (such as mentioning Android on iOS, or vice-versa), ranking claims, and future feature promises.
+- **Playbook and Script Mapping**:
+  - Script: `scripts/metadata-audit.py` (automates metadata checks on title, subtitle, keywords, and description).
+  - Patterns: `data/rejection-patterns.json` -> `BOTH-METADATA-DECORATION`, `APPLE-2.3-CROSS-PLATFORM-REFERENCE`, `APPLE-2.3-FUTURE-FUNCTIONALITY`, and `APPLE-2.3-NEGATIVE-APPLE-SENTIMENT`.
+  - Rules Reference: `references/rules/metadata.md`.
+- **Compliance Status**: Advisory. Multiple metadata checks are flagged by the automated scanner (e.g., `APPLE-2.3-CROSS-PLATFORM-REFERENCE` in 28+ files, `APPLE-2.3-FUTURE-FUNCTIONALITY`, and `APPLE-2.3-NEGATIVE-APPLE-SENTIMENT`). These are educational mistakes documented inside the rules and changelogs. They are false-positives for this repository but act as a success indicator for the scanner's detection capabilities.
+
+### 2.5 Age Rating
+- **Verification Scope**: Verify that Apple's age rating questions are fully answered and that any child-directed or mature content triggers appropriate gating and age-assurance mechanisms.
+- **Playbook and Script Mapping**:
+  - Script: `scripts/release-audit.py` (scans for pattern ID `APPLE-2.3-AGE-RATING-2026`).
+  - Checklist: `docs/PRE-SUBMISSION-CHECKLIST.md` under "Apple specific" and "Global specific".
+  - Rules Reference: `docs/GLOBAL-REGULATORY-2026.md` (detailing regional storefront blocks).
+- **Compliance Status**: Passed. The repository contains strict age rating rules and incorporates regional blocks (such as the 18-plus block in Australia, Brazil, and Singapore).
+
+### 2.6 AI Disclosures
+- **Verification Scope**: Check generative AI integrations for content moderation safeguards, appropriate age ratings, and in-app notices for EU users (EU AI Act Article 50(1)) and consent modals.
+- **Playbook and Script Mapping**:
+  - Script: `scripts/monitor-ai-policy.py` (checks for AI policy changes and scans for AI integration signals).
+  - Patterns: `data/rejection-patterns.json` -> `APPLE-5.1.2-AI-NO-CONSENT-MODAL` and `BOTH-AI-GENERATED-CONTENT`.
+  - Rules Reference: `docs/EU-REGULATORY-2026.md` and `references/guidelines/by-app-type/ai-and-generative-apps.md`.
+- **Compliance Status**: Passed. Rules for compliance with the EU AI Act (including Article 4 literacy records, Article 50 user disclosures, and watermarking) are fully integrated.
+
+### 2.7 Subscription Disclosures
+- **Verification Scope**: Ensure auto-renewal details, billing periods, pricing hierarchy, ToS/EULA links, and easy click-to-cancel pathways are clearly disclosed.
+- **Playbook and Script Mapping**:
+  - Script: `scripts/metadata-audit.py` (checks for subscription EULA/terms links).
+  - Patterns: `data/rejection-patterns.json` -> `APPLE-3.1.2-MISLEADING-PRICING` and `BOTH-SUBSCRIPTION-HARD-CANCEL`.
+  - Rules Reference: `references/rules/payments.md` and `references/guidelines/by-app-type/subscriptions-and-in-app-purchase.md`.
+- **Compliance Status**: Advisory. The automated scanner flags `BOTH-SUBSCRIPTION-HARD-CANCEL` because of hardcoded educational examples under `references/rules/payments.md`. This is a documented educational false-positive.
+
+### 2.8 Payment Compliance
+- **Verification Scope**: Ensure StoreKit and Play Billing are used for in-app digital goods (with StoreKit Restore Purchases functionality present). Verify third-party gateways are restricted to physical goods or exempt categories.
+- **Playbook and Script Mapping**:
+  - Script: `scripts/release-audit.py` (scans for patterns `APPLE-3.1.1-EXTERNAL-PAYMENT`, `GOOGLE-PLAY-BILLING`, and `APPLE-RESTORE-PURCHASES-MISSING`).
+  - Checklist: `docs/PRE-SUBMISSION-CHECKLIST.md` under "Monetization" and "Platform mechanics gate".
+  - Rules Reference: `references/rules/payments.md`.
+- **Compliance Status**: Advisory. The automated scanner flags `BOTH-LOOTBOX-ODDS` as high risk because of payment reference guides containing lootbox mechanics as an educational warning. This is an educational false-positive.
+
+### 2.9 Accessibility
+- **Verification Scope**: Audit accessibility support (VoiceOver/TalkBack labels, Dynamic Type, high contrast, EN 301 549 / WCAG 2.1 AA compliance).
+- **Playbook and Script Mapping**:
+  - Script: `scripts/accessibility-audit.py` (runs static analysis of accessibility rules).
+  - Checklist: `docs/PRE-SUBMISSION-CHECKLIST.md` under "EU specific" and "Platform mechanics gate".
+  - Rules Reference: `docs/PLATFORM-MECHANICS-2026.md` and `docs/ACCESSIBILITY-COMPLIANCE-REPORT.md`.
+- **Compliance Status**: Passed. Static analysis of accessibility rules completed and passed.
+
+### 2.10 Legal Documents
+- **Verification Scope**: Ensure presence of essential legal documents and disclosures (such as DSA trader status, child privacy/COPPA requirements, and EU AI Act Article 4/50 compliance).
+- **Playbook and Script Mapping**:
+  - Checklist: `docs/PRE-SUBMISSION-CHECKLIST.md` under "EU specific" and "Global specific".
+  - Rules Reference: `docs/EU-REGULATORY-2026.md` and `docs/GLOBAL-REGULATORY-2026.md`.
+- **Compliance Status**: Advisory. Scanners flag several references due to educational content, but the actual policy documentation and checklists are fully in place.
+
+### 2.11 Support URL
+- **Verification Scope**: Verify presence and reachability of a valid support/contact URL in metadata.
+- **Playbook and Script Mapping**:
+  - Script: `scripts/metadata-audit.py` (verifies support URL when metadata is provided).
+  - Patterns: `data/rejection-patterns.json` -> `BOTH-UNREACHABLE-METADATA-URL`.
+  - Checklist: `docs/PRE-SUBMISSION-CHECKLIST.md` under "Shared (both stores)".
+- **Compliance Status**: Advisory. The support URL check is flagged as advisory by the scanner since no live store metadata is submitted.
+
+### 2.12 Privacy Policy
+- **Verification Scope**: Confirm accurate and reachable privacy policy URL is declared in-app and in store metadata.
+- **Playbook and Script Mapping**:
+  - Script: `scripts/release-audit.py` (scans for pattern `BOTH-MISSING-PRIVACY-POLICY`).
+  - Patterns: `data/rejection-patterns.json` -> `APPLE-5.1.1-MISSING-PRIVACY-POLICY` and `GOOGLE-MISSING-PRIVACY-POLICY`.
+  - Checklist: `docs/PRE-SUBMISSION-CHECKLIST.md` under "Privacy and data".
+- **Compliance Status**: Advisory. The scanner flags `BOTH-MISSING-PRIVACY-POLICY` because of the empty local metadata directory structure.
+
+### 2.13 Terms of Service
+- **Verification Scope**: Ensure EULA/ToS is present and linked, especially for UGC or subscription features.
+- **Playbook and Script Mapping**:
+  - Script: `scripts/metadata-audit.py` (checks for terms in subscription listings).
+  - Patterns: `data/rejection-patterns.json` -> `APPLE-1.2-UGC-24H-ACTION` and `APPLE-3.1.2-MISLEADING-PRICING`.
+  - Checklist: `docs/PRE-SUBMISSION-CHECKLIST.md` under "Monetization".
+- **Compliance Status**: Passed. EULA and Terms of Service requirements are fully covered in the rules and checklists.
+
+### 2.14 Export Compliance
+- **Verification Scope**: Verify encryption declaration is set in `Info.plist` (using `ITSAppUsesNonExemptEncryption`).
+- **Playbook and Script Mapping**:
+  - Checklist: `docs/PRE-SUBMISSION-CHECKLIST.md` under "Apple specific".
+  - Patterns: `data/rejection-patterns.json` -> `APPLE-EXPORT-COMPLIANCE-MISSING`.
+  - Rules Reference: `references/rules/export.md`.
+- **Compliance Status**: Passed. Guidelines and plist integration steps are documented and verified.
+
+### 2.15 Encryption Declarations
+- **Verification Scope**: Verify encryption compliance and French ANSSI declaration upload if distributed in France.
+- **Playbook and Script Mapping**:
+  - Checklist: `docs/PRE-SUBMISSION-CHECKLIST.md` under "Apple specific" and "Platform mechanics gate".
+  - Patterns: `data/rejection-patterns.json` -> `APPLE-EXPORT-COMPLIANCE-MISSING`.
+  - Rules Reference: `references/rules/export.md` and `docs/PLATFORM-MECHANICS-2026.md`.
+- **Compliance Status**: Passed. Comprehensive guidelines and ANSSI reporting requirements are fully documented.
+
+---
+
+## 3. Severity-Ranked Findings Table
+
+The table below lists all issues flagged by the compliance scanner engines, categorized by severity, along with a classification of whether they represent true release risks or educational false-positives, and their remediation plans.
+
+| Finding ID | Severity | Domain | Source File | True Risk or False-Positive | Remediation / Mitigation Plan |
+| --- | --- | --- | --- | --- | --- |
+| BOTH-SUBSCRIPTION-HARD-CANCEL | HIGH | Subscription Disclosures | `references/rules/payments.md` | False-Positive (Educational) | This is an educational example of how not to hide subscription cancellation. No action is required as it serves as manual guidance. For production apps, implement a single-tap web or in-app cancellation mechanism. |
+| APPLE-2.3-CROSS-PLATFORM-REFERENCE | HIGH | Metadata | `README.md`, `AGENTS.md`, and 28 other files | False-Positive (Educational) | These cross-platform terms are used inside instructions and changelogs. They are educational false-positives. For production releases, ensure store listings contain no references to other platforms. |
+| BOTH-LOOTBOX-ODDS | HIGH | Legal Documents | `references/guidelines/by-app-type/games.md`, etc. | False-Positive (Educational) | The files contain rules directing developers to disclose odds. No action is required. In actual games, display exact odds on the purchase screen before a transaction occurs. |
+| BOTH-MISSING-PRIVACY-POLICY | HIGH | Privacy Policy | `scripts/release-audit.py` (Metadata Check) | False-Positive (No Store Build) | The playbook itself does not distribute a packaged binary or a store listing. True production builds must set a valid URL under the `privacy_policy_url` metadata attribute. |
+| BOTH-PLACEHOLDER | HIGH | Metadata | `scripts/release-audit.py` (Metadata Check) | False-Positive (No Store Build) | The playbook itself does not distribute a packaged binary or a store listing. True production builds must replace all placeholders with real content. |
+| APPLE-2.3-FUTURE-FUNCTIONALITY | MEDIUM | Metadata | `references/rules/metadata.md`, etc. | False-Positive (Educational) | The rules mention future functionality guidelines as a warning. False-positive for the playbook. For production, describe only features that are functional in the active build. |
+| APPLE-2.3-NEGATIVE-APPLE-SENTIMENT | MEDIUM | Metadata | `references/rules/metadata.md` | False-Positive (Educational) | This is an educational reference of what App Review rejects. False-positive for the playbook. For production, maintain completely neutral or positive sentiment toward platforms. |
+| BOTH-UNREACHABLE-METADATA-URL | MEDIUM | Support URL | `scripts/release-audit.py` (Metadata Check) | False-Positive (No Store Build) | The playbook does not host an active metadata description. Production apps must provide a valid support URL in their metadata config. |


### PR DESCRIPTION
This pull request adds the requested pre-release compliance audit report, documenting the evaluation of fifteen App Store and Google Play review domains. It includes a detailed section for each domain, mapping findings to specific automation scripts and playbooks, and provides a severity-ranked findings table classifying findings as either true risks or educational false-positives. All content is completely free of emojis, emoticons, or high-unicode symbols.

---
*PR created automatically by Jules for task [12568009265203144496](https://jules.google.com/task/12568009265203144496) started by @mjmirza*