### PR TITLE
Ignore generated compliance PR draft artifacts in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 __pycache__/
 *.pyc
 RELEASE-READINESS-REPORT.md
+docs/*_PR_DRAFT.md
+docs/*_COMPLIANCE_PR_DRAFT.md


### PR DESCRIPTION
Added docs/*_PR_DRAFT.md and docs/*_COMPLIANCE_PR_DRAFT.md patterns to .gitignore to ensure generated compliance PR drafts are treated as uncommitted runtime artifacts. Verified platform-specific AI policy monitoring script and tests.

---
*PR created automatically by Jules for task [4420349062362112986](https://jules.google.com/task/4420349062362112986) started by @mjmirza*