### PR TITLE
Ignore generated compliance PR drafts in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 __pycache__/
 *.pyc
 RELEASE-READINESS-REPORT.md
+docs/*_PR_DRAFT.md
+docs/*_COMPLIANCE_PR_DRAFT.md


### PR DESCRIPTION
Added pattern rules to .gitignore to prevent staging generated draft compliance PR files.

---
*PR created automatically by Jules for task [409922025773643566](https://jules.google.com/task/409922025773643566) started by @mjmirza*