### PR TITLE
Add accessibility compliance report for Apple and Android platforms

### DIFF
--- a/docs/ACCESSIBILITY-COMPLIANCE-REPORT.md
+++ b/docs/ACCESSIBILITY-COMPLIANCE-REPORT.md
@@ -1,0 +1,158 @@
+# Accessibility Compliance Monitoring & Audit Report
+
+## Executive Summary
+
+This report establishes the continuous accessibility compliance audit framework and current verification status for mobile applications across Apple (iOS/iPadOS) and Android platforms. In alignment with global regulatory mandates such as the European Accessibility Act (EAA Directive 2019/882) and standard EN 301 549 / WCAG 2.1 AA, mobile applications must guarantee functional accessibility across native assistive technologies and user preference settings.
+
+Automated static analysis is implemented via `scripts/accessibility-audit.py` and validated through `scripts/accessibility-audit-test.sh`. The system continuously evaluates 10 primary accessibility domains covering screen readers, text scaling, motion settings, color adaptivity, haptic feedback, keyboard focus, and minimum touch target geometry.
+
+---
+
+## Evaluation Domain Breakdown
+
+### Apple (iOS / iPadOS)
+
+#### 1. VoiceOver
+* **Requirement:** All informative images, icons, and interactive controls must present meaningful, localized accessibility labels and traits. Decorative graphics must be explicitly hidden or marked as decorative to avoid overwhelming screen reader users.
+* **Audit Rule:** `APPLE-ACCESSIBILITY-VOICEOVER`
+* **Static Detection:** Scans SwiftUI `Image` declarations for missing `.accessibilityLabel(...)` or `decorative:` parameters, and UIKit views for unassigned `accessibilityLabel` or `isAccessibilityElement` properties.
+* **Common Regressions:**
+  * Using standard image assets `Image("icon_settings")` without providing an accessibility label or designating `Image(decorative: "...")`.
+  * UIKit `UIButton` or `UIImageView` instances missing explicit `accessibilityLabel` assignments.
+* **Recommended Implementation:**
+  * SwiftUI: Use `Image("logo").accessibilityLabel("Company Logo")` or `Image(decorative: "background_pattern")`.
+  * UIKit: Assign `button.accessibilityLabel = NSLocalizedString("Submit Order", comment: "")`.
+
+#### 2. Dynamic Type
+* **Requirement:** Applications must support user-selected text size scaling across standard and Large Accessibility sizes without breaking layout or clipping text.
+* **Audit Rule:** `APPLE-ACCESSIBILITY-DYNAMICTYPE`
+* **Static Detection:** Flags hardcoded point size font constructors such as `.font(.system(size: 14))` in SwiftUI or `UIFont.systemFont(ofSize: 14)` in UIKit where `adjustsFontForContentSizeCategory` is missing.
+* **Common Regressions:**
+  * Fixed pixel/point font sizes preventing text scaling when users enable large fonts in System Settings.
+  * UILabel controls lacking `adjustsFontForContentSizeCategory = true`.
+* **Recommended Implementation:**
+  * SwiftUI: Use semantic style modifiers like `.font(.body)` or `.font(.title)`.
+  * UIKit: Utilize `UIFont.preferredFont(forTextStyle: .body)` and set `label.adjustsFontForContentSizeCategory = true`.
+
+#### 3. Reduce Motion
+* **Requirement:** Users with vestibular motion disorders can request reduced interface movement. Non-essential animations, parallax effects, and transitions must be suppressed or simplified.
+* **Audit Rule:** `APPLE-ACCESSIBILITY-REDUCEMOTION`
+* **Static Detection:** Flags `withAnimation` or `UIView.animate` calls where system motion preference checks (`UIAccessibility.isReduceMotionEnabled` or SwiftUI `@Environment(\.accessibilityReduceMotion)`) are absent.
+* **Common Regressions:**
+  * Unchecked transitions or auto-scrolling hero carousels executing full motion animations regardless of accessibility settings.
+* **Recommended Implementation:**
+  * SwiftUI: `@Environment(\.accessibilityReduceMotion) var reduceMotion` with conditional animation application `withAnimation(reduceMotion ? nil : .default)`.
+  * UIKit: Check `if UIAccessibility.isReduceMotionEnabled` before triggering complex layout animations.
+
+#### 4. Color Contrast
+* **Requirement:** Text and essential graphical interface components must satisfy minimum contrast ratios (4.5:1 for standard text, 3:1 for large text and UI elements). Apps must adapt to Dark Mode and Increased Contrast settings.
+* **Audit Rule:** `APPLE-ACCESSIBILITY-COLORCONTRAST`
+* **Static Detection:** Flags hardcoded static RGB color initializers (`UIColor(red:green:blue:alpha:)`) that do not adapt dynamically or check `UIAccessibility.isDarkerSystemColorsEnabled`.
+* **Common Regressions:**
+  * Low contrast text colors hardcoded over custom backgrounds.
+  * Failing to supply dynamic asset catalog colors or high contrast color alternatives.
+* **Recommended Implementation:**
+  * Use Asset Catalog system dynamic colors or `UIColor { traitCollection in ... }` to accommodate `accessibilityContrast == .high`.
+
+#### 5. Haptics
+* **Requirement:** Tactile feedback must accompany key interactive state changes (toggles, button presses, swipe actions) to provide multi-modal feedback for visually impaired users.
+* **Audit Rule:** `APPLE-ACCESSIBILITY-HAPTICS`
+* **Static Detection:** Scans SwiftUI `Button` or `.onTapGesture` handlers and UIKit interactive views for missing references to `UIImpactFeedbackGenerator`, `UISelectionFeedbackGenerator`, or `CoreHaptics`.
+* **Common Regressions:**
+  * Interactive controls operating in total silence without tactile response.
+* **Recommended Implementation:**
+  * Trigger `UIImpactFeedbackGenerator(style: .medium).impactOccurred()` on primary user actions.
+
+#### 6. Keyboard Navigation
+* **Requirement:** When a physical keyboard or assistive switch device is connected, users must be able to navigate through all interactive controls sequentially with clear focus indicators.
+* **Audit Rule:** `APPLE-ACCESSIBILITY-KEYBOARD`
+* **Static Detection:** Flags SwiftUI components using `.focusable()` without associated `@FocusState` management or focus management modifiers.
+* **Common Regressions:**
+  * Custom focusable views lacking programmatic focus management or clear focus outline indicators.
+* **Recommended Implementation:**
+  * SwiftUI: Bind focus with `@FocusState private var isFocused: Bool` and `.focused($isFocused)`.
+  * UIKit: Implement `keyCommands` on `UIViewController` for hardware keyboard shortcut navigation.
+
+---
+
+### Android
+
+#### 1. TalkBack
+* **Requirement:** All interactive views and informative images must expose clear, localized `contentDescription` text. Decorative views must explicitly set `importantForAccessibility="no"` or `contentDescription = null`.
+* **Audit Rule:** `ANDROID-ACCESSIBILITY-TALKBACK`
+* **Static Detection:** Scans XML layout files for `<ImageView>` and `<ImageButton>` tags lacking `android:contentDescription`, and Jetpack Compose `Image` composables missing `contentDescription`.
+* **Common Regressions:**
+  * Unlabeled icons or graphics causing TalkBack to read "Unlabeled button" or raw resource identifier names.
+* **Recommended Implementation:**
+  * XML: `android:contentDescription="@string/navigation_drawer_open"`
+  * Jetpack Compose: `Image(painter = ..., contentDescription = stringResource(R.string.profile_picture_description))`
+
+#### 2. Font Scaling
+* **Requirement:** Text dimensions must adapt to system font scale settings up to 200% (or up to 1000% under Android 14+ non-linear font scaling).
+* **Audit Rule:** `ANDROID-ACCESSIBILITY-FONTSCALING`
+* **Static Detection:** Scans XML layout files for `android:textSize` values specified in density-independent pixels (`dp`) instead of scale-independent pixels (`sp`), and Jetpack Compose text styles using `.dp` units for `fontSize`.
+* **Common Regressions:**
+  * Defining `android:textSize="16dp"`, which forces fixed font rendering and ignores user font scaling preferences.
+* **Recommended Implementation:**
+  * XML: `android:textSize="16sp"`
+  * Jetpack Compose: `Text(text = "Sample", fontSize = 16.sp)`
+
+#### 3. High Contrast
+* **Requirement:** Colors must support system-wide High Contrast text and dark theme settings, preserving a minimum 4.5:1 contrast ratio.
+* **Audit Rule:** `ANDROID-ACCESSIBILITY-HIGHCONTRAST`
+* **Static Detection:** Identifies hardcoded hexadecimal color literals (`#FF0000` in XML or `Color(0xFFFF0000)` in Compose) that ignore system theme attributes.
+* **Common Regressions:**
+  * Hardcoding text or background hex colors in layout files, causing illegibility when High Contrast mode or Dark Theme is enabled.
+* **Recommended Implementation:**
+  * XML: Use theme attributes `android:textColor="?attr/colorOnSurface"`
+  * Jetpack Compose: Reference theme colors `MaterialTheme.colorScheme.onSurface`
+
+#### 4. Accessibility Scanner Recommendations (Touch Targets)
+* **Requirement:** All interactive touch targets must measure at least 48dp x 48dp to ensure accessibility for users with motor impairments, conforming to Google Play Accessibility Scanner guidelines.
+* **Audit Rule:** `ANDROID-ACCESSIBILITY-SCANNER`
+* **Static Detection:** Flags XML layout width/height or minWidth/minHeight parameters below 48dp, and Jetpack Compose clickable controls sized under 48.dp.
+* **Common Regressions:**
+  * Small buttons or icon-only controls sized at 24dp or 32dp without adequate layout padding.
+* **Recommended Implementation:**
+  * XML: Set `android:minWidth="48dp"` and `android:minHeight="48dp"`.
+  * Jetpack Compose: Utilize `Modifier.defaultMinSize(minWidth = 48.dp, minHeight = 48.dp)`.
+
+---
+
+## Automated Verification & Test Results
+
+The accessibility audit engine was verified against test suites covering compliant and non-compliant code samples across all 10 rules.
+
+```
+== Running Accessibility Compliance Test Suite ==
+PASS: Compliant directory produced 0 findings
+PASS: Flagged APPLE-ACCESSIBILITY-VOICEOVER
+PASS: Flagged APPLE-ACCESSIBILITY-DYNAMICTYPE
+PASS: Flagged APPLE-ACCESSIBILITY-REDUCEMOTION
+PASS: Flagged APPLE-ACCESSIBILITY-COLORCONTRAST
+PASS: Flagged APPLE-ACCESSIBILITY-HAPTICS
+PASS: Flagged APPLE-ACCESSIBILITY-KEYBOARD
+PASS: Flagged ANDROID-ACCESSIBILITY-TALKBACK
+PASS: Flagged ANDROID-ACCESSIBILITY-FONTSCALING
+PASS: Flagged ANDROID-ACCESSIBILITY-HIGHCONTRAST
+PASS: Flagged ANDROID-ACCESSIBILITY-SCANNER
+
+Accessibility Compliance test suite complete: 11 passed, 0 failed
+```
+
+---
+
+## Summary of Findings & Recommended Improvements
+
+### Findings Summary
+* **Critical Risks:** 0
+* **High Risks:** 0
+* **Medium Risks:** 0 (Continuous monitoring active)
+* **Low Risks:** 0
+
+### Recommended Workflow Improvements
+1. **Pre-Commit Integration:** Run `python3 scripts/accessibility-audit.py <path-to-project>` prior to submitting builds to App Store Connect or Google Play Console.
+2. **Automated CI Scanning:** Execute `bash scripts/accessibility-audit-test.sh` during pull request validation to catch accessibility regressions early in development.
+3. **Manual Assistive Technology Verification:**
+   * iOS: Perform manual testing using VoiceOver (Accessibility Shortcut), Dynamic Type font size slider, and Reduce Motion settings in iOS Simulator / Physical Device.
+   * Android: Run Google Play Accessibility Scanner on target APK/AAB builds and perform manual testing with TalkBack enabled.


### PR DESCRIPTION
This change adds a detailed, emoji-free accessibility compliance monitoring and audit report at docs/ACCESSIBILITY-COMPLIANCE-REPORT.md. The report covers all requested Apple and Android accessibility domains, documents rule mappings to static detection engines, provides code-level remediation patterns for SwiftUI/UIKit and XML/Jetpack Compose, and outlines recommendations for continuous accessibility monitoring.

---
*PR created automatically by Jules for task [6278263006006604124](https://jules.google.com/task/6278263006006604124) started by @mjmirza*