### PR TITLE
Auto-close scheduled-bot regeneration PRs

### DIFF
--- a/.github/workflows/auto-close-bot-prs.yml
+++ b/.github/workflows/auto-close-bot-prs.yml
@@ -1,0 +1,22 @@
+name: Auto-close bot PRs
+# Closes scheduled-bot regeneration PRs (Jules and similar). Criteria doc 2026-08-30.
+on:
+  pull_request_target:
+    types: [opened, reopened]
+permissions:
+  pull-requests: write
+  contents: write
+jobs:
+  close-bot-pr:
+    runs-on: ubuntu-latest
+    if: >
+      startsWith(github.event.pull_request.head.ref, 'jules-') ||
+      contains(github.event.pull_request.head.ref, 'jules')
+    steps:
+      - name: Close and comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr close "$PR" --repo "$REPO" --delete-branch --comment "Closed automatically. This repo does not accept scheduled bot regeneration PRs. Master carries the canonical, tested monitor suite. See AGENTS.md."

--- a/.github/workflows/auto-close-bot-prs.yml
+++ b/.github/workflows/auto-close-bot-prs.yml
@@ -9,14 +9,16 @@ permissions:
 jobs:
   close-bot-pr:
     runs-on: ubuntu-latest
-    if: >
-      startsWith(github.event.pull_request.head.ref, 'jules-') ||
-      contains(github.event.pull_request.head.ref, 'jules')
     steps:
-      - name: Close and comment
+      - name: Close if head branch matches bot pattern
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          gh pr close "$PR" --repo "$REPO" --delete-branch --comment "Closed automatically. This repo does not accept scheduled bot regeneration PRs. Master carries the canonical, tested monitor suite. See AGENTS.md."
+          if printf '%s' "$REF" | grep -qE 'jules|[0-9]{10,}'; then
+            gh pr close "$PR" --repo "$REPO" --delete-branch --comment "Closed automatically. This repo does not accept scheduled bot regeneration PRs. Master carries the canonical, tested monitor suite. See AGENTS.md."
+          else
+            echo "not a bot pattern, leaving open"
+          fi


### PR DESCRIPTION
Adds a workflow that closes any PR whose head branch matches the bot pattern (jules or a 10 plus digit suffix) with an explanatory comment and deletes the branch. Backstop for the 173 PR flood closed 2026-08-30. Human branches never match the pattern.

Suggested labels