### PR TITLE
Regenerate references after pattern data changes

### DIFF
--- a/references/README.md
+++ b/references/README.md
@@ -8,7 +8,7 @@ A structured, AI loadable reference tree. Load the rule category and the app typ
 - [rules/privacy.md](rules/privacy.md). Privacy and data. 17 rules
 - [rules/payments.md](rules/payments.md). Payments, in app purchase, subscriptions. 8 rules
 - [rules/design.md](rules/design.md). Design and login. 4 rules
-- [rules/performance.md](rules/performance.md). Performance and completeness. 24 rules
+- [rules/performance.md](rules/performance.md). Performance and completeness. 25 rules
 - [rules/entitlements.md](rules/entitlements.md). Entitlements. 1 rules
 - [rules/safety.md](rules/safety.md). Safety and user generated content. 3 rules
 - [rules/android.md](rules/android.md). Google Play specific. 22 rules

--- a/references/rules/performance.md
+++ b/references/rules/performance.md
@@ -1,6 +1,6 @@
 # Rules. Performance and completeness
 
-24 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
+25 rules in this category. Generated from data/rejection-patterns.json. Each rule names the guideline, the severity, what triggers it, and the fix.
 
 ## APPLE-2.1-CLOUD-NOT-IN-PRODUCTION
 
@@ -287,6 +287,17 @@ How to detect.
 ```bash
 grep -rn 'gtag\|fbq\|google-analytics\|trackingPixel\|analytics.js\|hotjar' --include='*.js' --include='*.ts' --include='*.html' . && ! grep -rn 'consentTracking\|disableTracking\|optOutTracking\|trackingPreferences' .
 ```
+
+## BOTH-US-ASAA-AGE-SIGNALS-MISSING
+
+- Title. Missing store age-signal integration for US state ASAA duties
+- Platform. both
+- Guideline or policy. US state App Store Accountability Acts (Utah SB 142, Texas SB 2420, and successor state acts). See docs/GLOBAL-REGULATORY-2026.md section 2.2
+- Severity. high
+- What triggers it. Heuristic, not a certification. An app with accounts or age-gated features shows no integration with the store age signal surfaces (Declared Age Range on iOS, Play Age Signals API on Android) and no verifiable parental consent handling for minor accounts. Store-side duties began 6 May 2026 (Utah) and are documented with primary sources in docs/GLOBAL-REGULATORY-2026.md section 2.2.
+- How to fix it. Integrate the store age signal APIs, confirm verifiable parental consent for minor accounts before use, re-request consent on significant changes, and delete raw age verification data after verification.
+- Detection signals. ageCategory, minorUser, parentalConsent, DeclaredAgeRange, age-signals
+- Present means handled. verifyParentalConsent, handleAgeCategorySignal, rescindConsent, deleteAgeVerificationData
 
 ## APPLE-ACCESSIBILITY-COLORCONTRAST
 

--- a/references/rules/privacy.md
+++ b/references/rules/privacy.md
@@ -57,7 +57,7 @@ grep -rn 'createAccount\|signUp\|register' --include='*.swift' . && ! grep -rn '
 - Platform. apple
 - Guideline or policy. Privacy Manifest
 - Severity. critical
-- What triggers it. Required reason API usage or a commonly used third party SDK is present but no PrivacyInfo.xcprivacy is bundled, or an SDK lacks its signed manifest. Enforced by Apple at upload since 2024. The top modern Apple upload rejection.
+- What triggers it. Required reason API usage or a commonly used third party SDK is present but no PrivacyInfo.xcprivacy is bundled, or an SDK lacks its signed manifest. Enforced by Apple at upload since 2024.
 - How to fix it. Add a PrivacyInfo.xcprivacy with NSPrivacyAccessedAPITypes and approved reason codes, list NSPrivacyTrackingDomains, and confirm every third party SDK ships its signed manifest.
 - Detection signals. NSFileManager, UserDefaults, systemUptime, ProcessInfo, Firebase, Alamofire
 - Present means handled. PrivacyInfo.xcprivacy, NSPrivacyAccessedAPITypes

--- a/references/rules/safety.md
+++ b/references/rules/safety.md
@@ -4,11 +4,11 @@
 
 ## APPLE-1.2-UGC-24H-ACTION
 
-- Title. User generated content without the 24 hour action mechanism
+- Title. User generated content without the required moderation mechanisms
 - Platform. apple
 - Guideline or policy. 1.2
 - Severity. critical
-- What triggers it. UGC present without a EULA with zero tolerance for objectionable content, content filtering, a flag mechanism, user blocking, and the ability to act on a report within 24 hours by removing content and ejecting the user.
+- What triggers it. UGC present without content filtering, a mechanism to report offensive content with timely responses to concerns, the ability to block abusive users, and published contact information. Verified against the live guideline 2026-08-30, which requires timely responses rather than a fixed 24 hour deadline.
 - How to fix it. Add a zero tolerance EULA, content filtering, in app reporting, user blocking, and a process to act on reports within 24 hours. Source. real Apple Safety 1.2 rejection email.
 - Detection signals. post, comment, upload, chat, feed, community
 - Present means handled. report, block user, EULA, moderation


### PR DESCRIPTION
PR 444 changed data/rejection-patterns.json without regenerating the derived references directory, which the CI drift check correctly caught. This commits the regenerated output. No hand edits.

Suggested labels