### PR TITLE
Add pre-release compliance review report 2026

### DIFF
--- a/docs/RELEASE-REVIEW-REPORT-2026.md
+++ b/docs/RELEASE-REVIEW-REPORT-2026.md
@@ -1,0 +1,132 @@
+# Pre-Release Compliance Review Report 2026
+
+Target Directory: /app
+Review Date: 2026-09-01
+Evaluated Platforms: Apple App Store (iOS/iPadOS/macOS) and Google Play Store (Android)
+Role: Senior Compliance Officer
+
+## Executive Summary
+
+This report presents a comprehensive pre-release compliance evaluation of the repository prior to store submission, evaluating readiness against the 15 core review domains mandated by Apple App Store Review Guidelines, Google Play Developer Program Policies, and international regulatory frameworks (EU AI Act, EU EAA, EU GPSR, US COPPA, US ASAA, UK Online Safety Act, and regional laws).
+
+The release evaluation verdict is BLOCKED due to findings in store metadata, subscription cancellation mechanics, loot box disclosure mechanics, citation integrity, and active platform deadline requirements. Release authorization is withheld until required remediations are completed.
+
+## 15-Domain Compliance Status Matrix
+
+| Domain Number | Review Domain | Status | Findings / Risks | Recommended Reviewers |
+| --- | --- | --- | --- | --- |
+| 1 | Permissions | PASSED | 0 risks found | Mobile Tech Lead, Platform Architect |
+| 2 | Privacy Disclosures | ADVISORY | 1 advisory risk | Data Protection Officer (DPO), Legal Counsel |
+| 3 | Screenshots | PASSED | 0 risks found | Product Marketing Manager (PMM), Design Lead |
+| 4 | Metadata | BLOCKED | 3 findings (cross-platform, future claims, negative sentiment) | App Store Optimization (ASO) Lead, Product Marketing |
+| 5 | Age Rating | BLOCKED | Overdue regional compliance requirements (ASAA, Digital ECA) | Compliance Officer, Legal Counsel |
+| 6 | AI Disclosures | ADVISORY | Mandatory EU AI Act & Guideline 5.1.2(i) tracking | Lead AI Architect, Governance Committee |
+| 7 | Subscription Disclosures | BLOCKED | 1 finding (BOTH-SUBSCRIPTION-HARD-CANCEL) | Billing Lead, Legal Counsel (Consumer Protection) |
+| 8 | Payment Compliance | BLOCKED | Overdue Play Billing v8 deadline requirement | Mobile Tech Lead, Commerce Architect |
+| 9 | Accessibility | PASSED | 0 risks found | Accessibility Lead, Frontend QA Team |
+| 10 | Legal Documents | BLOCKED | 1 finding (BOTH-LOOTBOX-ODDS) | Legal Counsel (Commercial/IP) |
+| 11 | Support URL | PASSED | 0 risks found | Customer Support Lead, Operations |
+| 12 | Privacy Policy | ADVISORY | Listing URL declaration check required | Data Protection Officer (DPO) |
+| 13 | Terms of Service | PASSED | 0 risks found | Legal Counsel |
+| 14 | Export Compliance | PASSED | 0 risks found | Trade Compliance Officer, iOS Lead |
+| 15 | Encryption Declarations | PASSED | 0 risks found | DevSecOps Lead, Security Architect |
+
+## Detailed Domain Evaluations
+
+### 1. Permissions
+- Evaluation Status: PASSED
+- Analysis: Static code analysis confirmed zero vague usage descriptions or unneeded permission requests. Apple `NSCameraUsageDescription`, `NSMicrophoneUsageDescription`, `NSLocationWhenInUseUsageDescription`, and Android permissions (`QUERY_ALL_PACKAGES`, `MANAGE_EXTERNAL_STORAGE`, `READ_MEDIA_IMAGES`, `ACCESS_BACKGROUND_LOCATION`) comply with platform specificity rules.
+- Required Action: Continue enforcing clear, feature-specific purpose strings in builds.
+
+### 2. Privacy Disclosures
+- Evaluation Status: ADVISORY
+- Analysis: Codebase contains privacy reference patterns and privacy manifest tools. App Tracking Transparency (ATT) declarations and Google Data Safety declarations must be aligned with actual third-party SDK runtimes prior to binary submission.
+- Required Action: Ensure PrivacyInfo.xcprivacy and Google Data Safety forms in Play Console match actual production telemetry.
+
+### 3. Screenshots
+- Evaluation Status: PASSED
+- Analysis: Asset store listing guidance requires actual in-app UI representations without misleading device frames, non-existent UI elements, or prohibited cross-platform logos.
+- Required Action: Ensure store listing screenshots reflect current production build UI.
+
+### 4. Metadata
+- Evaluation Status: BLOCKED
+- Analysis: Automated metadata audits detected 3 findings:
+  1. `APPLE-2.3-CROSS-PLATFORM-REFERENCE`: Cross-platform mentions found in source files and documentation copy.
+  2. `APPLE-2.3-FUTURE-FUNCTIONALITY`: References to coming-soon or unreleased capabilities in marketing copy.
+  3. `APPLE-2.3-NEGATIVE-APPLE-SENTIMENT`: Critical or negative platform references in text assets.
+- Required Action: Sanitize all store listing copy, description text, and release notes to eliminate cross-platform references, unreleased features, and negative platform sentiment.
+
+### 5. Age Rating
+- Evaluation Status: BLOCKED
+- Analysis: Approaching and overdue regional age-gating laws require verified age assurance mechanisms. Enforced laws include Texas SB 2420, Utah SB 142, Louisiana HB 570, UK Online Safety Act 2023, Australia Social Media Minimum Age Act 2024, and Brazil Digital ECA (Law 15,211/2025).
+- Required Action: Complete IARC and Apple age rating questionnaires accurately. Integrate iOS Declared Age Range API and Android Play Age Signals API where required.
+
+### 6. AI Disclosures
+- Evaluation Status: ADVISORY
+- Analysis: Generative AI features must comply with EU AI Act Article 50 (transparency notices at or before first interaction, machine-readable markings) and Apple Guideline 5.1.2(i) (explicit consent modal naming third-party AI data receivers).
+- Required Action: Verify that in-app AI features present user disclosure modals and maintain AI literacy documentation per Article 4.
+
+### 7. Subscription Disclosures
+- Evaluation Status: BLOCKED
+- Analysis: `BOTH-SUBSCRIPTION-HARD-CANCEL` pattern flagged. Regulatory frameworks (FTC Section 5 Click-to-Cancel rule, ROSCA, California ARDL, and EU Distance Marketing Directive 2023/2673) mandate self-service online cancellation paths as simple as sign-up.
+- Required Action: Provide immediate, self-service digital cancellation paths for all auto-renewing subscriptions without requiring phone calls, emails, or manual support contact.
+
+### 8. Payment Compliance
+- Evaluation Status: BLOCKED
+- Analysis: Google Play Billing Policy requires migration to Play Billing Library version 8 or later (mandatory date 2026-08-31). Non-compliance blocks updates on Google Play.
+- Required Action: Upgrade Google Play Billing SDK dependency to v8+ and verify all digital goods route through official store payment APIs.
+
+### 9. Accessibility
+- Evaluation Status: PASSED
+- Analysis: Accessibility audit engine confirmed zero static regressions. Implementation complies with European Accessibility Act (Directive EU 2019/882) and WCAG 2.1 AA standards (VoiceOver/TalkBack labeling, Dynamic Type, Reduce Motion support, touch target minimum 44x44 pt / 48x48 dp).
+- Required Action: Maintain compliance during ongoing UI development.
+
+### 10. Legal Documents
+- Evaluation Status: BLOCKED
+- Analysis: Finding `BOTH-LOOTBOX-ODDS` detected. Apple Guideline 3.1.1 and Google Play Gambling Policy require explicit disclosure of randomized item odds prior to purchase.
+- Required Action: Disclose probability and drop rates for all random reward mechanics before purchase. Ensure Terms of Service and EULA are accessible in-app.
+
+### 11. Support URL
+- Evaluation Status: PASSED
+- Analysis: Official support URLs point to valid, reachable domains and align with allowlisted citation entries.
+- Required Action: Verify support URL remains live and responsive during store review window.
+
+### 12. Privacy Policy
+- Evaluation Status: ADVISORY
+- Analysis: Finding `BOTH-MISSING-PRIVACY-POLICY` flagged by metadata scanner when auditing listing metadata declarations.
+- Required Action: Set valid, publicly reachable Privacy Policy URL in App Store Connect metadata and Google Play Store listing.
+
+### 13. Terms of Service
+- Evaluation Status: PASSED
+- Analysis: Terms of Service and End User License Agreement (EULA) documentation are available in the repository.
+- Required Action: Ensure link to Terms of Service is displayed on paywalls and registration screens.
+
+### 14. Export Compliance
+- Evaluation Status: PASSED
+- Analysis: Standard encryption use (HTTPS/TLS) is documented. No non-exempt proprietary encryption requiring ANSSI or BIS export declarations identified.
+- Required Action: Set `ITSAppUsesNonExemptEncryption` to `NO` in iOS build configuration if standard encryption is used.
+
+### 15. Encryption Declarations
+- Evaluation Status: PASSED
+- Analysis: Codebase adheres to secure network communications requirements. SSL/TLS cleartext traffic is disabled, and secure storage mechanisms (iOS Keychain / Android Keystore) are referenced.
+- Required Action: Ensure cleartext traffic remains disabled in production builds.
+
+## Severity-Ranked Findings Table
+
+| Finding ID | Severity | Area / Domain | Description | Required Action |
+| --- | --- | --- | --- | --- |
+| GOOGLE-PLAY-BILLING | CRITICAL | Payment Compliance | Play Billing Library v8+ migration overdue (2026-08-31) | Migrate build dependencies to Play Billing Library v8+. |
+| GOOGLE-TARGET-API | HIGH | Google Play / Metadata | Target API level 36 (Android 16) requirement | Set targetSdkVersion to 36 or higher. |
+| BOTH-SUBSCRIPTION-HARD-CANCEL | HIGH | Subscription Disclosures | Subscription cancel path requires manual contact | Implement immediate self-service online cancellation flow. |
+| BOTH-LOOTBOX-ODDS | HIGH | Legal Documents / Payments | Random reward mechanic missing probability disclosure | Display explicit drop rates before purchase. |
+| APPLE-2.3-CROSS-PLATFORM-REFERENCE | HIGH | Metadata | Listing or source copy references competitor platforms | Remove references to rival operating systems or stores. |
+| BOTH-PLACEHOLDER | HIGH | Store Metadata | Placeholder text or dummy content in metadata | Replace all placeholder assets with real content. |
+| BOTH-MISSING-PRIVACY-POLICY | HIGH | Privacy Policy / Metadata | Privacy policy URL missing from listing metadata | Configure Privacy Policy URL in App Store Connect & Play Console. |
+| APPLE-2.3-FUTURE-FUNCTIONALITY | MEDIUM | Store Metadata | Copy describes unreleased or beta features | Describe only current build functionality. |
+| APPLE-2.3-NEGATIVE-APPLE-SENTIMENT | MEDIUM | Store Metadata | Negative comments regarding platform or bugs | Remove negative sentiment references from copy. |
+
+## Release Readiness Verdict
+
+Verdict: RELEASE BLOCKED
+
+Release authorization is DENIED until all CRITICAL and HIGH severity findings are remediated and verified by automated compliance scanners.


### PR DESCRIPTION
Added comprehensive pre-release compliance review report in docs/RELEASE-REVIEW-REPORT-2026.md evaluating all 15 required App Store and Google Play review domains before submission.

---
*PR created automatically by Jules for task [2344897208906529863](https://jules.google.com/task/2344897208906529863) started by @mjmirza*