### PR TITLE
fix(recipes): add detection recipe for BOTH-US-ASAA-AGE-SIGNALS-MISSING

### DIFF
--- a/data/detection-recipes.json
+++ b/data/detection-recipes.json
@@ -82,6 +82,7 @@
     "RN-PRIVACY-MANIFEST-MISSING": "grep -qE '\"react-native\"|\"expo\"' package.json 2>/dev/null && grep -rn 'Firebase\\|AsyncStorage\\|expo-file-system' --include='*.ts' --include='*.tsx' . 2>/dev/null && ! find . -name 'PrivacyInfo.xcprivacy' | grep -q .",
     "IONIC-4.2-THIN-WRAPPER": "grep -rlE 'WKWebView|loadRequest|Capacitor|Cordova' --include='*.ts' --include='*.js' --include='*.swift' . 2>/dev/null | wc -l   # then count distinct @capacitor/(status-bar|splash-screen|push-notifications|haptics) markers, fewer than 2 is a thin wrapper",
     "IONIC-UIWEBVIEW-DEPRECATED": "grep -rn 'UIWebView' --include='*.swift' --include='*.m' . 2>/dev/null",
-    "IONIC-PRIVACY-MANIFEST-MISSING": "grep -rq '@capacitor/\\|Capacitor\\.' --include='*.ts' . 2>/dev/null && ! find . -name 'PrivacyInfo.xcprivacy' | grep -q ."
+    "IONIC-PRIVACY-MANIFEST-MISSING": "grep -rq '@capacitor/\\|Capacitor\\.' --include='*.ts' . 2>/dev/null && ! find . -name 'PrivacyInfo.xcprivacy' | grep -q .",
+    "BOTH-US-ASAA-AGE-SIGNALS-MISSING": "grep -rnE 'ageCategory|minorUser|parentalConsent|DeclaredAgeRange|age-signals' --include='*.swift' --include='*.kt' --include='*.java' --include='*.xml' . 2>/dev/null && ! grep -rnE 'verifyParentalConsent|handleAgeCategorySignal|rescindConsent|deleteAgeVerificationData' --include='*.swift' --include='*.kt' --include='*.java' --include='*.xml' . 2>/dev/null"
   }
 }


### PR DESCRIPTION
Adds the missing detection recipe entry for `BOTH-US-ASAA-AGE-SIGNALS-MISSING` in `data/detection-recipes.json`, resolving the validation warning from `scripts/validate.py` and bringing complete detection recipe coverage across all 90 rejection patterns.

---
*PR created automatically by Jules for task [14920463317380350138](https://jules.google.com/task/14920463317380350138) started by @mjmirza*