### PR TITLE
feat: add output-docs and pr-output CLI flags to Regulatory Intelligence Monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 __pycache__/
 *.pyc
 RELEASE-READINESS-REPORT.md
+docs/*_PR_DRAFT.md
+docs/*_COMPLIANCE_PR_DRAFT.md

--- a/docs/REGULATORY-MONITOR-REPORT-2026.md
+++ b/docs/REGULATORY-MONITOR-REPORT-2026.md
@@ -1,0 +1,22 @@
+<!-- REGULATORY_MONITOR_START -->
+# Regulatory Intelligence Monitoring Report
+
+This report is continuously generated and updated by `scripts/monitor-regulatory.py` to track global regulatory developments and compliance readiness across all supported jurisdictions.
+
+## Monitored Developments Log
+
+### 1. [GDPR] Unverified rumors of GDPR policy changes on Reddit forum
+- **Jurisdiction**: European Union
+- **Impact Level**: High
+- **Published Date**: Sun, 26 Jul 2026 12:00:00 GMT
+- **Official Resource**: [https://reddit.com/r/privacy/comments/12345/GDPR_rumor](https://reddit.com/r/privacy/comments/12345/GDPR_rumor)
+- **Scan Verdict**: BLOCKED: Compliance Pull Request generation blocked. Announcement source is Priority 5 (unverified secondary source).
+
+## Migration Recommendations & Implementation Tasks
+
+### Tasks for GDPR
+- **Jurisdiction**: European Union
+- **Impact Level**: High
+- **Status**: BLOCKED. Source is an unverified secondary source.
+
+<!-- REGULATORY_MONITOR_END -->

--- a/scripts/monitor-regulatory-test.sh
+++ b/scripts/monitor-regulatory-test.sh
@@ -109,6 +109,37 @@ if echo "$EU_JSON" | grep -q '"proposed_pull_request": null'; then
 fi
 echo "[PASS] Allowed verified Priority 1 sources successfully"
 
+# Test 8: Verify --output-docs and --pr-output file generation
+echo "[TEST] Verifying --output-docs and --pr-output file generation..."
+TEST_DOCS_OUT="$REPO_ROOT/docs/TEST_REGULATORY_REPORT.md"
+TEST_PR_OUT="$REPO_ROOT/docs/TEST_REGULATORY_PR_DRAFT.md"
+rm -f "$TEST_DOCS_OUT" "$TEST_PR_OUT"
+
+python3 "$MON_SCRIPT" --project "$REPO_ROOT" --simulate "EU AI Act" --output-docs "$TEST_DOCS_OUT" --pr-output "$TEST_PR_OUT" > /dev/null
+
+if [ ! -f "$TEST_DOCS_OUT" ]; then
+  echo "[ERROR] Failed to generate documentation report at $TEST_DOCS_OUT"
+  exit 1
+fi
+
+if [ ! -f "$TEST_PR_OUT" ]; then
+  echo "[ERROR] Failed to generate PR draft at $TEST_PR_OUT"
+  exit 1
+fi
+
+if ! grep -q "Regulatory Intelligence Monitoring Report" "$TEST_DOCS_OUT"; then
+  echo "[ERROR] Documentation report header missing in $TEST_DOCS_OUT"
+  exit 1
+fi
+
+if ! grep -q "## Approver recommendations" "$TEST_PR_OUT"; then
+  echo "[ERROR] PR draft missing 15-section structure in $TEST_PR_OUT"
+  exit 1
+fi
+
+rm -f "$TEST_DOCS_OUT" "$TEST_PR_OUT"
+echo "[PASS] Successfully generated and verified output docs and PR draft files"
+
 echo ""
 echo "[SUCCESS] All tests passed successfully."
 exit 0

--- a/scripts/monitor-regulatory.py
+++ b/scripts/monitor-regulatory.py
@@ -1045,6 +1045,58 @@ def run_monitor(project_path=".", simulate_track=None, verbose=False):
     return report_items, processed_tracks
 
 
+def update_documentation_report(report_items, output_filepath):
+    """
+    Overwrites or updates the Regulatory Intelligence Monitoring Report in
+    output_filepath (e.g. docs/REGULATORY-MONITOR-REPORT-2026.md).
+    Follows a strict emoji-free policy.
+    """
+    lines = [
+        "<!-- REGULATORY_MONITOR_START -->",
+        "# Regulatory Intelligence Monitoring Report",
+        "",
+        "This report is continuously generated and updated by `scripts/monitor-regulatory.py` to track global regulatory developments and compliance readiness across all supported jurisdictions.",
+        "",
+        "## Monitored Developments Log",
+        "",
+    ]
+
+    for idx, item in enumerate(report_items, 1):
+        lines.append(f"### {idx}. [{item['track']}] {item['announcement_title']}")
+        lines.append(f"- **Jurisdiction**: {item['jurisdiction']}")
+        lines.append(f"- **Impact Level**: {item['compliance_impact']}")
+        lines.append(f"- **Published Date**: {item['announcement_pubDate']}")
+        lines.append(f"- **Official Resource**: [{item['announcement_link']}]({item['announcement_link']})")
+        lines.append(f"- **Scan Verdict**: {item['scan_verdict']}")
+        lines.append("")
+
+    lines.append("## Migration Recommendations & Implementation Tasks")
+    lines.append("")
+
+    for item in report_items:
+        track = item["track"]
+        lines.append(f"### Tasks for {track}")
+        lines.append(f"- **Jurisdiction**: {item['jurisdiction']}")
+        lines.append(f"- **Impact Level**: {item['compliance_impact']}")
+
+        if item["proposed_pull_request"] is None:
+            lines.append("- **Status**: BLOCKED. Source is an unverified secondary source.")
+        else:
+            for task in item["migration_tasks"]:
+                lines.append(f"- [ ] {task}")
+        lines.append("")
+
+    lines.append("<!-- REGULATORY_MONITOR_END -->")
+
+    os.makedirs(os.path.dirname(output_filepath) or ".", exist_ok=True)
+    try:
+        with open(output_filepath, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+    except Exception as e:
+        import sys
+        print(f"Error writing documentation report to {output_filepath}: {e}", file=sys.stderr)
+
+
 def print_text_report(report_items, project_path):
     print("=" * 80)
     print("               REGULATORY INTELLIGENCE MONITOR COMPLIANCE REPORT")
@@ -1106,6 +1158,18 @@ def main():
         "--simulate", help="Simulate a regulatory change by track name or keyword"
     )
     parser.add_argument(
+        "--output-docs",
+        type=str,
+        default="docs/REGULATORY-MONITOR-REPORT-2026.md",
+        help="Filepath to write or update the regulatory monitoring report (default: docs/REGULATORY-MONITOR-REPORT-2026.md)",
+    )
+    parser.add_argument(
+        "--pr-output",
+        type=str,
+        default="docs/REGULATORY_COMPLIANCE_PR_DRAFT.md",
+        help="Filepath to save the generated Pull Request draft (default: docs/REGULATORY_COMPLIANCE_PR_DRAFT.md)",
+    )
+    parser.add_argument(
         "--json", action="store_true", help="Output report in JSON format"
     )
     parser.add_argument(
@@ -1117,6 +1181,28 @@ def main():
     report_items, processed = run_monitor(
         project_path=args.project, simulate_track=args.simulate, verbose=args.verbose
     )
+
+    # 1. Update/generate documentation report
+    if args.output_docs:
+        update_documentation_report(report_items, args.output_docs)
+
+    # 2. Save drafted Pull Request description if any verified item produced one
+    if args.pr_output:
+        # Save first verified PR draft or combined PR draft if available
+        first_pr = None
+        for item in report_items:
+            if item.get("proposed_pull_request"):
+                first_pr = item["proposed_pull_request"]
+                break
+
+        if first_pr:
+            os.makedirs(os.path.dirname(args.pr_output) or ".", exist_ok=True)
+            try:
+                with open(args.pr_output, "w", encoding="utf-8") as f:
+                    f.write(first_pr["description"])
+            except Exception as e:
+                import sys
+                print(f"Failed to write PR draft to {args.pr_output}: {e}", file=sys.stderr)
 
     if args.json:
         print(json.dumps(report_items, indent=2))


### PR DESCRIPTION
Enhanced the Regulatory Intelligence Agent Monitor utility `scripts/monitor-regulatory.py` to support `--output-docs` (generating/updating `docs/REGULATORY-MONITOR-REPORT-2026.md`) and `--pr-output` (exporting 15-section PR drafts). Updated `.gitignore` and `scripts/monitor-regulatory-test.sh` to cover new file generation capabilities.

---
*PR created automatically by Jules for task [13423815328661107168](https://jules.google.com/task/13423815328661107168) started by @mjmirza*