### PR TITLE
feat(regulatory): add documentation and PR generation to monitor-regulatory.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 __pycache__/
 *.pyc
 RELEASE-READINESS-REPORT.md
+docs/*_PR_DRAFT.md
+docs/*_COMPLIANCE_PR_DRAFT.md

--- a/docs/REGULATORY-MONITOR-REPORT-2026.md
+++ b/docs/REGULATORY-MONITOR-REPORT-2026.md
@@ -1,0 +1,52 @@
+<!-- REGULATORY_MONITOR_REPORT_START -->
+# Global Regulatory Intelligence Compliance & Monitoring Report (2026)
+
+This report is continuously generated and updated by `scripts/monitor-regulatory.py` to track global regulatory developments and compliance requirements across major jurisdictions.
+
+## Monitored Regulatory Updates Log
+
+### 1. [GDPR] Unverified rumors of GDPR policy changes on Reddit forum
+- **Jurisdiction**: European Union
+- **Published Date**: Sun, 26 Jul 2026 12:00:00 GMT
+- **Official Resource**: [https://reddit.com/r/privacy/comments/12345/GDPR_rumor](https://reddit.com/r/privacy/comments/12345/GDPR_rumor)
+- **Compliance Impact**: High
+- **Scan Verdict**: BLOCKED: Compliance Pull Request generation blocked. Announcement source is Priority 5 (unverified secondary source).
+
+- **Identified Affected Files**:
+  - `CHANGELOG.md`
+  - `AGENTS.md`
+  - `README.md`
+  - `references/guidelines/by-app-type/vpn-and-networking.md`
+  - `references/rules/privacy.md`
+  - `references/rules/performance.md`
+  - `references/rules/android.md`
+  - `docs/EU-REGULATORY-2026.md`
+  - `docs/REGULATORY-TIMELINE.md`
+  - `docs/BY-APP-TYPE.md`
+  - `docs/ANDROID-POLICY-MIGRATION.md`
+  - `docs/MOBILE-PRIVACY-MONITOR-2026.md`
+  - `docs/GOOGLE-PLAY.md`
+  - `docs/ADVANCED-2026.md`
+  - `docs/REGULATORY-GAP-REPORT-2026.md`
+  - `docs/GLOBAL-REGULATORY-2026.md`
+  - `docs/REGULATORY_COMPLIANCE_PR_DRAFT.md`
+  - `docs/PRIVACY-POLICY-MIGRATION.md`
+  - `docs/APPLE.md`
+  - `docs/REGULATORY-MONITOR-REPORT-2026.md`
+  - `docs/PRE-SUBMISSION-CHECKLIST.md`
+  - `data/regulatory-deadlines.json`
+  - `data/detection-recipes.json`
+  - `data/rejection-patterns.json`
+
+- **Suggested Migration Tasks**:
+  - [ ] Ensure the app implements a clear, prominent consent modal before collecting personal data.
+  - [ ] Offer a genuine in-app account deletion mechanism that removes all associated personal data.
+  - [ ] Audit all analytics and tracking SDKs to ensure data flows are disabled until opt-in consent is given.
+
+## Automated Regulatory Compliance Instructions & Next Steps
+
+1. **Review High Priority Frameworks**: Prioritize EU AI Act, US COPPA, and UK/US child safety mandates.
+2. **Validate Citation Trust**: Ensure all citations derive from Priority 1 official regulatory bodies.
+3. **Execute Pre-Submission Verification**: Run `python3 scripts/release-audit.py` prior to shipping new builds.
+
+<!-- REGULATORY_MONITOR_REPORT_END -->

--- a/scripts/monitor-regulatory-test.sh
+++ b/scripts/monitor-regulatory-test.sh
@@ -109,6 +109,27 @@ if echo "$EU_JSON" | grep -q '"proposed_pull_request": null'; then
 fi
 echo "[PASS] Allowed verified Priority 1 sources successfully"
 
+# Test 8: Verify file output options (--output-docs and --pr-output)
+echo "[TEST] Verifying --output-docs and --pr-output file generation..."
+TEST_DOCS_OUT="/tmp/test_regulatory_doc.md"
+TEST_PR_OUT="/tmp/test_regulatory_pr.md"
+rm -f "$TEST_DOCS_OUT" "$TEST_PR_OUT"
+
+python3 "$MON_SCRIPT" --project "$REPO_ROOT" --simulate "EU AI Act" --output-docs "$TEST_DOCS_OUT" --pr-output "$TEST_PR_OUT" > /dev/null
+
+if [ ! -f "$TEST_DOCS_OUT" ]; then
+  echo "[ERROR] Expected documentation report file was not created: $TEST_DOCS_OUT"
+  exit 1
+fi
+
+if [ ! -f "$TEST_PR_OUT" ]; then
+  echo "[ERROR] Expected PR draft output file was not created: $TEST_PR_OUT"
+  exit 1
+fi
+
+rm -f "$TEST_DOCS_OUT" "$TEST_PR_OUT"
+echo "[PASS] --output-docs and --pr-output flags generated output files successfully"
+
 echo ""
 echo "[SUCCESS] All tests passed successfully."
 exit 0

--- a/scripts/monitor-regulatory.py
+++ b/scripts/monitor-regulatory.py
@@ -1045,6 +1045,62 @@ def run_monitor(project_path=".", simulate_track=None, verbose=False):
     return report_items, processed_tracks
 
 
+def update_documentation_report(report_items, output_filepath):
+    """
+    Overwrites or updates the regulatory monitoring report in docs/REGULATORY-MONITOR-REPORT-2026.md.
+    """
+    lines = [
+        "<!-- REGULATORY_MONITOR_REPORT_START -->",
+        "# Global Regulatory Intelligence Compliance & Monitoring Report (2026)",
+        "",
+        "This report is continuously generated and updated by `scripts/monitor-regulatory.py` to track global regulatory developments and compliance requirements across major jurisdictions.",
+        "",
+        "## Monitored Regulatory Updates Log",
+        "",
+    ]
+
+    if not report_items:
+        lines.append("No active regulatory updates detected.")
+    else:
+        for idx, item in enumerate(report_items, 1):
+            lines.append(f"### {idx}. [{item['track']}] {item['announcement_title']}")
+            lines.append(f"- **Jurisdiction**: {item['jurisdiction']}")
+            lines.append(f"- **Published Date**: {item['announcement_pubDate']}")
+            lines.append(f"- **Official Resource**: [{item['announcement_link']}]({item['announcement_link']})")
+            lines.append(f"- **Compliance Impact**: {item['compliance_impact']}")
+            lines.append(f"- **Scan Verdict**: {item['scan_verdict']}")
+            lines.append("")
+
+            if item["affected_files"]:
+                lines.append("- **Identified Affected Files**:")
+                for f in item["affected_files"]:
+                    lines.append(f"  - `{f}`")
+                lines.append("")
+
+            lines.append("- **Suggested Migration Tasks**:")
+            for task in item["migration_tasks"]:
+                lines.append(f"  - [ ] {task}")
+            lines.append("")
+
+    lines.append("## Automated Regulatory Compliance Instructions & Next Steps")
+    lines.append("")
+    lines.append("1. **Review High Priority Frameworks**: Prioritize EU AI Act, US COPPA, and UK/US child safety mandates.")
+    lines.append("2. **Validate Citation Trust**: Ensure all citations derive from Priority 1 official regulatory bodies.")
+    lines.append("3. **Execute Pre-Submission Verification**: Run `python3 scripts/release-audit.py` prior to shipping new builds.")
+    lines.append("")
+    lines.append("<!-- REGULATORY_MONITOR_REPORT_END -->")
+
+    os.makedirs(os.path.dirname(output_filepath) or ".", exist_ok=True)
+    try:
+        with open(output_filepath, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+        import sys
+        print(f"Regulatory documentation report updated successfully at: {output_filepath}", file=sys.stderr)
+    except Exception as e:
+        import sys
+        print(f"Error writing documentation to {output_filepath}: {e}", file=sys.stderr)
+
+
 def print_text_report(report_items, project_path):
     print("=" * 80)
     print("               REGULATORY INTELLIGENCE MONITOR COMPLIANCE REPORT")
@@ -1106,6 +1162,16 @@ def main():
         "--simulate", help="Simulate a regulatory change by track name or keyword"
     )
     parser.add_argument(
+        "--output-docs",
+        default="docs/REGULATORY-MONITOR-REPORT-2026.md",
+        help="Filepath to write documentation report",
+    )
+    parser.add_argument(
+        "--pr-output",
+        default="docs/REGULATORY_COMPLIANCE_PR_DRAFT.md",
+        help="Filepath to save drafted Pull Request",
+    )
+    parser.add_argument(
         "--json", action="store_true", help="Output report in JSON format"
     )
     parser.add_argument(
@@ -1117,6 +1183,25 @@ def main():
     report_items, processed = run_monitor(
         project_path=args.project, simulate_track=args.simulate, verbose=args.verbose
     )
+
+    if args.output_docs:
+        update_documentation_report(report_items, args.output_docs)
+
+    if args.pr_output:
+        import sys
+        pr_descriptions = [
+            item["proposed_pull_request"]["description"]
+            for item in report_items
+            if item.get("proposed_pull_request")
+        ]
+        if pr_descriptions:
+            os.makedirs(os.path.dirname(args.pr_output) or ".", exist_ok=True)
+            try:
+                with open(args.pr_output, "w", encoding="utf-8") as f:
+                    f.write("\n\n---\n\n".join(pr_descriptions) + "\n")
+                print(f"PR draft written successfully to: {args.pr_output}", file=sys.stderr)
+            except Exception as e:
+                print(f"Failed to write PR draft to {args.pr_output}: {e}", file=sys.stderr)
 
     if args.json:
         print(json.dumps(report_items, indent=2))


### PR DESCRIPTION
This PR updates `scripts/monitor-regulatory.py` to support `--output-docs` and `--pr-output` flags for generating markdown monitoring reports and 15-section draft Pull Request proposals, updates `.gitignore` to ignore generated PR drafts, adds test coverage in `scripts/monitor-regulatory-test.sh`, and creates `docs/REGULATORY-MONITOR-REPORT-2026.md`.

---
*PR created automatically by Jules for task [13569420743407065714](https://jules.google.com/task/13569420743407065714) started by @mjmirza*