### PR TITLE
docs: install prompts walk account readiness and the deadline window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this playbook are recorded here. The format follows Keep 
 
 ### Fixed
 
+- The README install prompt and the one-time check prompt never asked the agent to walk the account and program readiness checklist or the 90-day regulatory deadline window, both of which a code scan cannot see. Both prompts now do.
 - docs/PLATFORM-MECHANICS-2026.md cited the wrong announcement id for the June 2026 Guideline 4.3 tightening and still said API 35. Now a233fmpw and API 36 with the 1 November 2026 extension.
 - docs/EU-REGULATORY-2026.md section 2.3 said the EU unified fee model was not implemented. It applies from 1 October 2026 (Core Technology Commission, Attachment 14).
 - Past-dated deadlines added in this sweep carry absorbed_into, so the deadline checker points at the owning pattern or doc section instead of reporting them overdue.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Steps:
 4. Add a standing instruction to your agent config: for any iOS or Android work, always adhere to the Apple App Store Review Guidelines and Google Play policies, run the audit before submission, and never say an app is clear to submit while a critical risk stands.
 5. Run the guard against my current project and show me the ranked findings:
    bash ~/.claude/hooks/app-store-compliance-guard.sh /path/to/my/app
+   Then walk the account and program readiness section of docs/PRE-SUBMISSION-CHECKLIST.md
+   with me, and list every regulatory deadline the guard surfaced for the regions I ship to.
+   The code scan cannot see whether my developer account is active, whether every agreement
+   and attachment is accepted, or whether my Play account and package names are registered,
+   and in 2026 those block a first launch for weeks before review starts.
 6. Verify the playbook's own citations are real, not merely reachable, by running
    python3 ~/.claude/skills/app-store-compliance/scripts/verify-citations.py --files docs/ data/
 7. Tell me exactly what you installed and how I run an audit any time.
@@ -67,7 +72,7 @@ on my behalf. Ask me, show me the link, and let me decide.
 Want only a one time check, no install? Paste this instead.
 
 ```
-Read https://github.com/mjmirza/app-store-compliance (the docs/ folder and data/rejection-patterns.json), then audit my app at <path to my app> against every Apple App Store and Google Play rejection pattern. Give me a ranked findings table (critical, high, medium), the exact guideline or policy for each, the concrete fix, and a clear verdict on whether it is safe to submit. Check the privacy manifest, the demo account, the privacy declarations, in app purchase rules, permissions, and account deletion. Then audit the store listing with scripts/metadata-audit.py against the metadata directory if I have pulled it.
+Read https://github.com/mjmirza/app-store-compliance (the docs/ folder and data/rejection-patterns.json), then audit my app at <path to my app> against every Apple App Store and Google Play rejection pattern. Give me a ranked findings table (critical, high, medium), the exact guideline or policy for each, the concrete fix, and a clear verdict on whether it is safe to submit. Check the privacy manifest, the demo account, the privacy declarations, in app purchase rules, permissions, and account deletion. Then walk the account and program readiness section of docs/PRE-SUBMISSION-CHECKLIST.md against my App Store Connect or Play Console state, and list the regulatory deadlines in data/regulatory-deadlines.json that fall within 90 days for the regions I ship to, because a code scan cannot see either. Then audit the store listing with scripts/metadata-audit.py against the metadata directory if I have pulled it.
 
 Read only. Do not modify my project. Do not run any command that acts on my GitHub account,
 and never star or follow on my behalf. If the audit caught something that would have cost me


### PR DESCRIPTION
## Summary

The README install prompt and the one-time check prompt asked the agent to run the guard and audit the code. Neither asked it to walk the account and program readiness section added in #521, or to list the regulatory deadlines inside the 90-day window for the regions the app ships to. A code scan cannot see enrollment state, agreement and attachment acceptance, or Play organization and package registration, and the community evidence in docs/GAP-ANALYSIS-2026-09.md shows those block a first launch for weeks before review starts.

## Changes

- Install prompt step 5 now walks the account and program readiness checklist and lists the surfaced deadlines after the guard run.
- One-time check prompt now does the same against App Store Connect or Play Console state.
- CHANGELOG entry under Fixed.

## Test plan

- Prose only, no data or script change. CI validate and references drift run unchanged.